### PR TITLE
Feature/create profile page

### DIFF
--- a/lib/features/auth/data/auth_repository.dart
+++ b/lib/features/auth/data/auth_repository.dart
@@ -6,19 +6,30 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 final authRepositoryProvider = Provider((_) => AuthRepository());
 
 class AuthRepository {
- Future<SignUpResult> signUp({
-    required String password,
+  Future<SignUpResult> signUpWithProfile({
     required String email,
+    required String password,
+    required String username,
+    String? bio,
+    String? twitterId,
   }) async {
     try {
+      final userAttributes = <AuthUserAttributeKey, String>{
+        AuthUserAttributeKey.email: email,
+        AuthUserAttributeKey.preferredUsername: username,
+      };
+      if (bio != null && bio.trim().isNotEmpty) {
+        userAttributes[const CognitoUserAttributeKey.custom('bio')] = bio;
+      }
+      if (twitterId != null && twitterId.trim().isNotEmpty) {
+        userAttributes[const CognitoUserAttributeKey.custom('twitter_id')] = twitterId;
+      }
+
       final options = SignUpOptions(
-        userAttributes: {
-          AuthUserAttributeKey.email: email,
-        },
+        userAttributes: userAttributes,
       );
-      // username引数にはemailを渡す
       return await Amplify.Auth.signUp(
-        username: email,
+        username: email, // Cognitoのusernameはemailを使用
         password: password,
         options: options,
       );

--- a/lib/features/auth/data/auth_repository.dart
+++ b/lib/features/auth/data/auth_repository.dart
@@ -6,9 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 final authRepositoryProvider = Provider((_) => AuthRepository());
 
 class AuthRepository {
-  // ... (signUp, confirmSignUp, signIn, fetchUserAttributes, resetPassword, confirmResetPassword, signOut, fetchCurrentUserAttributesは変更なし) ...
-  Future<SignUpResult> signUp({
-     required String username,
+ Future<SignUpResult> signUp({
     required String password,
     required String email,
   }) async {
@@ -16,9 +14,9 @@ class AuthRepository {
       final options = SignUpOptions(
         userAttributes: {
           AuthUserAttributeKey.email: email,
-           AuthUserAttributeKey.preferredUsername: username,
         },
       );
+      // username引数にはemailを渡す
       return await Amplify.Auth.signUp(
         username: email,
         password: password,
@@ -114,10 +112,11 @@ class AuthRepository {
     }
   }
   /// ユーザー属性を更新します。
+  /// bioやtwitterIdがnullや空文字の場合は更新しません。
   Future<void> updateUserAttributes({
     required String username,
-    required String bio,
-    required String twitterId,
+    String? bio,
+    String? twitterId,
   }) async {
     try {
       final attributesToUpdate = [
@@ -125,15 +124,24 @@ class AuthRepository {
           userAttributeKey: AuthUserAttributeKey.preferredUsername,
           value: username,
         ),
-        AuthUserAttribute(
+      ];
+
+      // bioがnullや空でなければ属性リストに追加
+      if (bio != null && bio.trim().isNotEmpty) {
+        attributesToUpdate.add(AuthUserAttribute(
           userAttributeKey: const CognitoUserAttributeKey.custom('bio'),
           value: bio,
-        ),
-        AuthUserAttribute(
+        ));
+      }
+
+      // twitterIdがnullや空でなければ属性リストに追加
+      if (twitterId != null && twitterId.trim().isNotEmpty) {
+        attributesToUpdate.add(AuthUserAttribute(
           userAttributeKey: const CognitoUserAttributeKey.custom('twitter_id'),
           value: twitterId,
-        ),
-      ];
+        ));
+      }
+      
       await Amplify.Auth.updateUserAttributes(attributes: attributesToUpdate);
     } on AuthException catch (e) {
       safePrint('属性の更新中にエラーが発生しました: $e');

--- a/lib/features/auth/data/auth_repository.dart
+++ b/lib/features/auth/data/auth_repository.dart
@@ -53,6 +53,15 @@ class AuthRepository {
     }
   }
 
+    /// サインアップ確認コードを再送します。
+  Future<void> resendSignUpCode({required String username}) async {
+    try {
+      await Amplify.Auth.resendSignUpCode(username: username);
+    } on AuthException {
+      rethrow;
+    }
+  }
+
   // サインイン処理
   Future<SignInResult> signIn({
     required String username,

--- a/lib/features/auth/data/auth_repository.dart
+++ b/lib/features/auth/data/auth_repository.dart
@@ -3,11 +3,10 @@
 import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-// Riverpodでこのリポジトリを提供するためのProvider
 final authRepositoryProvider = Provider((_) => AuthRepository());
 
 class AuthRepository {
-  // サインアップ処理
+  // ... (signUp, confirmSignUp, signIn, fetchUserAttributes, resetPassword, confirmResetPassword, signOut, fetchCurrentUserAttributesは変更なし) ...
   Future<SignUpResult> signUp({
      required String username,
     required String password,
@@ -114,36 +113,29 @@ class AuthRepository {
       rethrow;
     }
   }
-
-  /// ユーザー属性（ユーザー名、自己紹介）を更新または新規作成します。
-   Future<void> updateUserAttributes({
+  /// ユーザー属性を更新します。
+  Future<void> updateUserAttributes({
     required String username,
     required String bio,
+    required String twitterId,
   }) async {
     try {
-      await Amplify.Auth.updateUserAttributes(
-        attributes: [
-          AuthUserAttribute(
-            userAttributeKey: AuthUserAttributeKey.preferredUsername,
-            value: username,
-          ),
-        ],
-      );
-
-      // 自己紹介が空でなければ更新処理を行う
-      if (bio.trim().isNotEmpty) {
-        await Amplify.Auth.updateUserAttributes(
-          attributes: [
-            AuthUserAttribute(
-              userAttributeKey: const CognitoUserAttributeKey.custom('bio'),
-              value: bio,
-            ),
-          ],
-        );
-      }
-
+      final attributesToUpdate = [
+        AuthUserAttribute(
+          userAttributeKey: AuthUserAttributeKey.preferredUsername,
+          value: username,
+        ),
+        AuthUserAttribute(
+          userAttributeKey: const CognitoUserAttributeKey.custom('bio'),
+          value: bio,
+        ),
+        AuthUserAttribute(
+          userAttributeKey: const CognitoUserAttributeKey.custom('twitter_id'),
+          value: twitterId,
+        ),
+      ];
+      await Amplify.Auth.updateUserAttributes(attributes: attributesToUpdate);
     } on AuthException catch (e) {
-      // 本番環境ではより適切なエラーハンドリングを推奨
       safePrint('属性の更新中にエラーが発生しました: $e');
       rethrow;
     }

--- a/lib/features/auth/presentation/notifiers/auth_state_notifier.dart
+++ b/lib/features/auth/presentation/notifiers/auth_state_notifier.dart
@@ -60,40 +60,47 @@ class AuthStateNotifier extends StateNotifier<AuthState> {
   AuthStateNotifier(this._authRepository)
       : super(const AuthState(status: AuthStatus.unauthenticated));
 // ... (signUp, confirmSignUp, signIn, resetPassword, confirmResetPassword, signOut, updateUsername は変更なし) ...
-  Future<void> signUp(String password, String email) async {
+   Future<void> createProfileAndSignUp({
+    required String email,
+    required String password,
+    required String username,
+    String? bio,
+    String? twitterId,
+  }) async {
     state = state.copyWith(status: AuthStatus.loading, errorMessage: null);
     try {
-      // ▼▼▼ repositoryの呼び出しも修正 ▼▼▼
-      final result = await _authRepository.signUp(
-        password: password,
+      final result = await _authRepository.signUpWithProfile(
         email: email,
+        password: password,
+        username: username,
+        bio: bio,
+        twitterId: twitterId,
       );
       if (result.isSignUpComplete) {
         state = state.copyWith(
             status: AuthStatus.unauthenticated,
             errorMessage: '登録が完了しました。ログインしてください。');
       } else {
-        // 確認コード画面には引き続きemailを渡す
         state = state.copyWith(
             status: AuthStatus.confirmationRequired,
             usernameForConfirmation: email);
       }
-    } catch (e) {
-      state = state.copyWith(status: AuthStatus.error, errorMessage: '登録に失敗しました: $e');
+    } on AuthException catch (e) {
+      state = state.copyWith(status: AuthStatus.error, errorMessage: '登録に失敗しました: ${e.message}');
     }
   }
 
   // ▼▼▼ 3. confirmSignUpメソッドの成功時の処理を修正 ▼▼▼
-  Future<void> confirmSignUp(String username, String confirmationCode) async {
+Future<void> confirmSignUp(String username, String confirmationCode) async {
     state = state.copyWith(status: AuthStatus.loading, errorMessage: null);
     try {
       await _authRepository.confirmSignUp(
           username: username, confirmationCode: confirmationCode);
-      // 成功したら、unauthenticated ではなく profileSetupRequired に遷移
+      // 成功したら、ログインできるようにunauthenticated状態に遷移
       state = state.copyWith(
-          status: AuthStatus.profileSetupRequired,
-          usernameForConfirmation: username // emailを保持しておく
-          );
+        status: AuthStatus.unauthenticated,
+        errorMessage: '認証が完了しました。ログインしてください。',
+      );
     } catch (e) {
       state =
           state.copyWith(status: AuthStatus.error, errorMessage: '認証に失敗しました: $e');

--- a/lib/features/auth/presentation/notifiers/auth_state_notifier.dart
+++ b/lib/features/auth/presentation/notifiers/auth_state_notifier.dart
@@ -4,7 +4,7 @@ import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../data/auth_repository.dart';
 
-// 認証状態を表現するenum
+// ... (enum AuthStatus, class AuthState, final authStateNotifierProvider は変更なし) ...
 enum AuthStatus {
   initial,
   loading,
@@ -53,13 +53,13 @@ final authStateNotifierProvider =
   return AuthStateNotifier(ref.watch(authRepositoryProvider));
 });
 
-// StateNotifier本体
+
 class AuthStateNotifier extends StateNotifier<AuthState> {
   final AuthRepository _authRepository;
 
   AuthStateNotifier(this._authRepository)
       : super(const AuthState(status: AuthStatus.unauthenticated));
-
+// ... (signUp, confirmSignUp, signIn, resetPassword, confirmResetPassword, signOut, updateUsername は変更なし) ...
   Future<void> signUp( String username,String password, String email) async {
     state = state.copyWith(status: AuthStatus.loading, errorMessage: null);
     try {
@@ -117,15 +117,19 @@ class AuthStateNotifier extends StateNotifier<AuthState> {
           status: AuthStatus.error, errorMessage: 'ログインに失敗しました: $e');
     }
   }
-
-  
-
-  Future<bool> setupProfile({required String username, required String bio}) async {
+  Future<bool> setupProfile({
+    required String username,
+    required String bio,
+    required String twitterId,
+  }) async {
     state = state.copyWith(status: AuthStatus.loading);
     try {
-      await _authRepository.updateUserAttributes(username: username, bio: bio);
-      // 成功したら authenticated 状態に遷移して完了
-      state = state.copyWith(status: AuthStatus.authenticated);
+      await _authRepository.updateUserAttributes(
+        username: username,
+        bio: bio,
+        twitterId: twitterId,
+      );
+      state = state.copyWith(status: AuthStatus.authenticated, username: username);
       return true;
     } catch (e) {
       state = state.copyWith(
@@ -133,8 +137,7 @@ class AuthStateNotifier extends StateNotifier<AuthState> {
       return false;
     }
   }
-
-  // --- 以下を追加 ---
+    // --- 以下を追加 ---
   Future<void> resetPassword(String username) async {
     state = state.copyWith(status: AuthStatus.loading, errorMessage: null);
     try {
@@ -191,5 +194,4 @@ class AuthStateNotifier extends StateNotifier<AuthState> {
   void updateUsername(String newUsername) {
     state = state.copyWith(username: newUsername);
   }
-  // --- ▲▲▲ ここまで追加 ▲▲▲ ---
 }

--- a/lib/features/auth/presentation/notifiers/auth_state_notifier.dart
+++ b/lib/features/auth/presentation/notifiers/auth_state_notifier.dart
@@ -12,8 +12,8 @@ enum AuthStatus {
   unauthenticated,
   confirmationRequired,
   profileSetupRequired,
-  passwordResetRequired, // 追加
-  passwordResetSuccess,  // 追加
+  passwordResetRequired, 
+  passwordResetSuccess,  
   error,
 }
 
@@ -60,11 +60,11 @@ class AuthStateNotifier extends StateNotifier<AuthState> {
   AuthStateNotifier(this._authRepository)
       : super(const AuthState(status: AuthStatus.unauthenticated));
 // ... (signUp, confirmSignUp, signIn, resetPassword, confirmResetPassword, signOut, updateUsername は変更なし) ...
-  Future<void> signUp( String username,String password, String email) async {
+  Future<void> signUp(String password, String email) async {
     state = state.copyWith(status: AuthStatus.loading, errorMessage: null);
     try {
+      // ▼▼▼ repositoryの呼び出しも修正 ▼▼▼
       final result = await _authRepository.signUp(
-          username: username,
         password: password,
         email: email,
       );
@@ -73,6 +73,7 @@ class AuthStateNotifier extends StateNotifier<AuthState> {
             status: AuthStatus.unauthenticated,
             errorMessage: '登録が完了しました。ログインしてください。');
       } else {
+        // 確認コード画面には引き続きemailを渡す
         state = state.copyWith(
             status: AuthStatus.confirmationRequired,
             usernameForConfirmation: email);

--- a/lib/features/auth/presentation/notifiers/auth_state_notifier.dart
+++ b/lib/features/auth/presentation/notifiers/auth_state_notifier.dart
@@ -1,10 +1,9 @@
-// ファイルパス: lib/notifiers/auth_state_notifier.dart
+// ファイルパス: lib/features/auth/presentation/notifiers/auth_state_notifier.dart
 
 import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../data/auth_repository.dart';
 
-// ... (enum AuthStatus, class AuthState, final authStateNotifierProvider は変更なし) ...
 enum AuthStatus {
   initial,
   loading,
@@ -12,17 +11,16 @@ enum AuthStatus {
   unauthenticated,
   confirmationRequired,
   profileSetupRequired,
-  passwordResetRequired, 
-  passwordResetSuccess,  
+  passwordResetRequired,
+  passwordResetSuccess,
   error,
 }
 
-// 状態クラス
 class AuthState {
   final AuthStatus status;
   final String? errorMessage;
   final String? usernameForConfirmation;
-    final String? username;
+  final String? username;
 
   const AuthState({
     this.status = AuthStatus.initial,
@@ -39,28 +37,26 @@ class AuthState {
   }) {
     return AuthState(
       status: status ?? this.status,
-      errorMessage: errorMessage, // nullを許容してエラーメッセージをクリアできるようにする
+      errorMessage: errorMessage,
       usernameForConfirmation:
           usernameForConfirmation ?? this.usernameForConfirmation,
-          username: username ?? this.username,
+      username: username ?? this.username,
     );
   }
 }
 
-// StateNotifierProviderの定義
 final authStateNotifierProvider =
     StateNotifierProvider<AuthStateNotifier, AuthState>((ref) {
   return AuthStateNotifier(ref.watch(authRepositoryProvider));
 });
-
 
 class AuthStateNotifier extends StateNotifier<AuthState> {
   final AuthRepository _authRepository;
 
   AuthStateNotifier(this._authRepository)
       : super(const AuthState(status: AuthStatus.unauthenticated));
-// ... (signUp, confirmSignUp, signIn, resetPassword, confirmResetPassword, signOut, updateUsername は変更なし) ...
-   Future<void> createProfileAndSignUp({
+
+  Future<void> createProfileAndSignUp({
     required String email,
     required String password,
     required String username,
@@ -77,20 +73,34 @@ class AuthStateNotifier extends StateNotifier<AuthState> {
         twitterId: twitterId,
       );
       if (result.isSignUpComplete) {
-        state = state.copyWith(
-            status: AuthStatus.unauthenticated,
-            errorMessage: '登録が完了しました。ログインしてください。');
+        // 通常は発生しないが、Cognitoの設定によってはコード不要で登録完了する場合がある
+        await signIn(email, password);
       } else {
         state = state.copyWith(
             status: AuthStatus.confirmationRequired,
             usernameForConfirmation: email);
       }
+    } on UsernameExistsException {
+      // ユーザーが既に存在し、未確認の場合
+      try {
+        await _authRepository.resendSignUpCode(username: email);
+        state = state.copyWith(
+          status: AuthStatus.confirmationRequired,
+          usernameForConfirmation: email,
+          errorMessage: 'このメールアドレスは登録済みです。確認コードを再送信しました。',
+        );
+      } catch (e) {
+        state = state.copyWith(
+            status: AuthStatus.error, errorMessage: '確認コードの再送信に失敗しました。');
+      }
     } on AuthException catch (e) {
-      state = state.copyWith(status: AuthStatus.error, errorMessage: '登録に失敗しました: ${e.message}');
+      state = state.copyWith(
+          status: AuthStatus.error, errorMessage: '登録に失敗しました: ${e.message}');
     }
   }
 
-Future<void> confirmSignUp(String username, String confirmationCode, String password) async {
+  Future<void> confirmSignUp(
+      String username, String confirmationCode, String password) async {
     state = state.copyWith(status: AuthStatus.loading, errorMessage: null);
     try {
       await _authRepository.confirmSignUp(
@@ -98,58 +108,52 @@ Future<void> confirmSignUp(String username, String confirmationCode, String pass
       // 認証成功後、自動でサインイン
       await signIn(username, password);
     } catch (e) {
-      state =
-          state.copyWith(status: AuthStatus.error, errorMessage: '認証に失敗しました: $e');
+      state = state.copyWith(
+          status: AuthStatus.error, errorMessage: '認証に失敗しました: $e');
     }
   }
 
- Future<void> signIn(String email, String password) async {
-    state = state.copyWith(status: AuthStatus.loading, errorMessage: null);
+  Future<void> signIn(String email, String password) async {
+    // confirmSignUpから呼ばれる場合も考慮し、loading状態を一度だけ設定
+    if (state.status != AuthStatus.loading) {
+      state = state.copyWith(status: AuthStatus.loading, errorMessage: null);
+    }
     try {
       await _authRepository.signIn(username: email, password: password);
-      // --- 以下を追加 ---
       final attributes = await _authRepository.fetchUserAttributes();
       final username = attributes
           .firstWhere((element) =>
-              element.userAttributeKey == AuthUserAttributeKey.preferredUsername)
+              element.userAttributeKey ==
+              AuthUserAttributeKey.preferredUsername)
           .value;
       state =
           state.copyWith(status: AuthStatus.authenticated, username: username);
-      // --- ここまで追加 ---
-    } catch (e) {
+    } on UserNotConfirmedException {
+      // ユーザーが未確認の場合
+      try {
+        await _authRepository.resendSignUpCode(username: email);
+        state = state.copyWith(
+            status: AuthStatus.confirmationRequired,
+            usernameForConfirmation: email,
+            errorMessage: 'このアカウントは未確認です。確認コードをメールアドレスに送信しました。');
+      } catch (e) {
+        state = state.copyWith(
+            status: AuthStatus.error, errorMessage: '確認コードの再送信に失敗しました。');
+      }
+    } on AuthException catch (e) {
       state = state.copyWith(
-          status: AuthStatus.error, errorMessage: 'ログインに失敗しました: $e');
+          status: AuthStatus.error, errorMessage: 'ログインに失敗しました: ${e.message}');
     }
   }
-  Future<bool> setupProfile({
-    required String username,
-    required String bio,
-    required String twitterId,
-  }) async {
-    state = state.copyWith(status: AuthStatus.loading);
-    try {
-      await _authRepository.updateUserAttributes(
-        username: username,
-        bio: bio,
-        twitterId: twitterId,
-      );
-      state = state.copyWith(status: AuthStatus.authenticated, username: username);
-      return true;
-    } catch (e) {
-      state = state.copyWith(
-          status: AuthStatus.error, errorMessage: 'プロフィールの設定に失敗しました: $e');
-      return false;
-    }
-  }
-    // --- 以下を追加 ---
+
   Future<void> resetPassword(String username) async {
     state = state.copyWith(status: AuthStatus.loading, errorMessage: null);
     try {
       await _authRepository.resetPassword(username);
       state = state.copyWith(status: AuthStatus.passwordResetRequired);
     } on UserNotFoundException {
-      state =
-          state.copyWith(status: AuthStatus.error, errorMessage: '登録されていないメールアドレスです');
+      state = state.copyWith(
+          status: AuthStatus.error, errorMessage: '登録されていないメールアドレスです');
     } catch (e) {
       state = state.copyWith(
           status: AuthStatus.error, errorMessage: '予期せぬエラーが発生しました: $e');
@@ -186,14 +190,12 @@ Future<void> confirmSignUp(String username, String confirmationCode, String pass
           status: AuthStatus.error, errorMessage: '予期せぬエラーが発生しました: $e');
     }
   }
-  // --- ここまで追加 ---
 
   Future<void> signOut() async {
     await _authRepository.signOut();
     state = const AuthState(status: AuthStatus.unauthenticated);
   }
 
-  // --- ▼▼▼ ここから追加 ▼▼▼ ---
   /// プロフィール更新時にユーザー名を同期するためのメソッド
   void updateUsername(String newUsername) {
     state = state.copyWith(username: newUsername);

--- a/lib/features/auth/presentation/notifiers/auth_state_notifier.dart
+++ b/lib/features/auth/presentation/notifiers/auth_state_notifier.dart
@@ -90,17 +90,13 @@ class AuthStateNotifier extends StateNotifier<AuthState> {
     }
   }
 
-  // ▼▼▼ 3. confirmSignUpメソッドの成功時の処理を修正 ▼▼▼
-Future<void> confirmSignUp(String username, String confirmationCode) async {
+Future<void> confirmSignUp(String username, String confirmationCode, String password) async {
     state = state.copyWith(status: AuthStatus.loading, errorMessage: null);
     try {
       await _authRepository.confirmSignUp(
           username: username, confirmationCode: confirmationCode);
-      // 成功したら、ログインできるようにunauthenticated状態に遷移
-      state = state.copyWith(
-        status: AuthStatus.unauthenticated,
-        errorMessage: '認証が完了しました。ログインしてください。',
-      );
+      // 認証成功後、自動でサインイン
+      await signIn(username, password);
     } catch (e) {
       state =
           state.copyWith(status: AuthStatus.error, errorMessage: '認証に失敗しました: $e');

--- a/lib/features/auth/presentation/pages/confirmation_page.dart
+++ b/lib/features/auth/presentation/pages/confirmation_page.dart
@@ -2,7 +2,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:my_madamis_app/features/auth/presentation/pages/create_profile_page.dart';
+import 'package:my_madamis_app/features/auth/presentation/pages/login_page.dart';
 import '../notifiers/auth_state_notifier.dart';
 
 class ConfirmationPage extends ConsumerWidget {
@@ -14,14 +14,24 @@ class ConfirmationPage extends ConsumerWidget {
     final codeController = TextEditingController();
     
     ref.listen(authStateNotifierProvider, (_, next) {
-      // ▼▼▼ 遷移条件と遷移先を修正 ▼▼▼
-      if (next.status == AuthStatus.profileSetupRequired) {
+      if (next.status == AuthStatus.unauthenticated && next.errorMessage != null) {
+        // 登録完了メッセージを表示
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(next.errorMessage!)),
+        );
+        // ログインページに遷移
         Navigator.of(context).pushAndRemoveUntil(
-          MaterialPageRoute(builder: (_) => const CreateProfilePage()),
+          MaterialPageRoute(builder: (_) => const LoginPage()),
           (route) => false,
+        );
+      } else if (next.status == AuthStatus.error) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('エラー: ${next.errorMessage}')),
         );
       }
     });
+
+    final authState = ref.watch(authStateNotifierProvider);
 
     return Scaffold(
       appBar: AppBar(title: const Text('コード認証')),
@@ -32,10 +42,13 @@ class ConfirmationPage extends ConsumerWidget {
             Text('$username で登録したメールアドレスに届いたコードを入力してください。'),
             TextFormField(controller: codeController, decoration: const InputDecoration(labelText: '認証コード')),
             const SizedBox(height: 20),
-            ElevatedButton(
-              onPressed: () => ref.read(authStateNotifierProvider.notifier).confirmSignUp(username, codeController.text),
-              child: const Text('認証'),
-            ),
+            if (authState.status == AuthStatus.loading)
+              const CircularProgressIndicator()
+            else
+              ElevatedButton(
+                onPressed: () => ref.read(authStateNotifierProvider.notifier).confirmSignUp(username, codeController.text),
+                child: const Text('認証'),
+              ),
           ],
         ),
       ),

--- a/lib/features/auth/presentation/pages/confirmation_page.dart
+++ b/lib/features/auth/presentation/pages/confirmation_page.dart
@@ -2,26 +2,25 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:my_madamis_app/features/auth/presentation/pages/login_page.dart';
+import 'package:my_madamis_app/features/home/presentation/pages/home_page.dart';
 import '../notifiers/auth_state_notifier.dart';
 
 class ConfirmationPage extends ConsumerWidget {
   final String username;
-  const ConfirmationPage({super.key, required this.username});
+  final String password;
+  const ConfirmationPage({super.key, required this.username, required this.password});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final codeController = TextEditingController();
     
     ref.listen(authStateNotifierProvider, (_, next) {
-      if (next.status == AuthStatus.unauthenticated && next.errorMessage != null) {
-        // 登録完了メッセージを表示
+      if (next.status == AuthStatus.authenticated) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(next.errorMessage!)),
+          const SnackBar(content: Text('登録が完了しました。')),
         );
-        // ログインページに遷移
         Navigator.of(context).pushAndRemoveUntil(
-          MaterialPageRoute(builder: (_) => const LoginPage()),
+          MaterialPageRoute(builder: (_) => const HomePage()),
           (route) => false,
         );
       } else if (next.status == AuthStatus.error) {
@@ -46,7 +45,11 @@ class ConfirmationPage extends ConsumerWidget {
               const CircularProgressIndicator()
             else
               ElevatedButton(
-                onPressed: () => ref.read(authStateNotifierProvider.notifier).confirmSignUp(username, codeController.text),
+                onPressed: () => ref.read(authStateNotifierProvider.notifier).confirmSignUp(
+                      username,
+                      codeController.text,
+                      password,
+                    ),
                 child: const Text('認証'),
               ),
           ],

--- a/lib/features/auth/presentation/pages/create_profile_page.dart
+++ b/lib/features/auth/presentation/pages/create_profile_page.dart
@@ -1,7 +1,6 @@
 // ファイルパス: lib/features/auth/presentation/pages/create_profile_page.dart
 
 import 'package:flutter/material.dart';
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:my_madamis_app/features/home/presentation/pages/home_page.dart';
 import '../notifiers/auth_state_notifier.dart';
@@ -17,12 +16,14 @@ class _CreateProfilePageState extends ConsumerState<CreateProfilePage> {
   final _formKey = GlobalKey<FormState>();
   final _usernameController = TextEditingController();
   final _bioController = TextEditingController();
+  final _twitterController = TextEditingController();
   bool _isLoading = false;
 
   @override
   void dispose() {
     _usernameController.dispose();
     _bioController.dispose();
+    _twitterController.dispose();
     super.dispose();
   }
 
@@ -33,9 +34,11 @@ class _CreateProfilePageState extends ConsumerState<CreateProfilePage> {
     setState(() => _isLoading = true);
 
     final notifier = ref.read(authStateNotifierProvider.notifier);
+    // setupProfileメソッドを新しい引数で呼び出す（auth_state_notifier.dartの修正も必要）
     final success = await notifier.setupProfile(
       username: _usernameController.text,
-      bio: _bioController.text, // bioは空文字のまま渡す
+      bio: _bioController.text,
+      twitterId: _twitterController.text,
     );
 
     if (mounted) {
@@ -50,12 +53,11 @@ class _CreateProfilePageState extends ConsumerState<CreateProfilePage> {
 
   @override
   Widget build(BuildContext context) {
-    // 認証状態が変化したらホーム画面へ遷移
     ref.listen(authStateNotifierProvider, (_, next) {
       if (next.status == AuthStatus.authenticated) {
         Navigator.of(context).pushAndRemoveUntil(
           MaterialPageRoute(builder: (_) => const HomePage()),
-          (route) => false, // 途中の画面をすべて履歴から削除
+          (route) => false,
         );
       }
     });
@@ -74,7 +76,7 @@ class _CreateProfilePageState extends ConsumerState<CreateProfilePage> {
                 style: Theme.of(context).textTheme.headlineMedium,
               ),
               const SizedBox(height: 8),
-              const Text('他のユーザーに表示される名前を設定してください。'),
+              const Text('他のユーザーに表示される情報を設定してください。'),
               const SizedBox(height: 24),
               TextFormField(
                 controller: _usernameController,
@@ -99,6 +101,15 @@ class _CreateProfilePageState extends ConsumerState<CreateProfilePage> {
                 ),
                 maxLines: 5,
                 maxLength: 200,
+              ),
+              const SizedBox(height: 16.0),
+              TextFormField(
+                controller: _twitterController,
+                decoration: const InputDecoration(
+                  labelText: 'X (Twitter) ID (任意)',
+                  border: OutlineInputBorder(),
+                  prefixText: '@',
+                ),
               ),
               const SizedBox(height: 24.0),
               ElevatedButton(

--- a/lib/features/auth/presentation/pages/create_profile_page.dart
+++ b/lib/features/auth/presentation/pages/create_profile_page.dart
@@ -2,11 +2,12 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:my_madamis_app/features/home/presentation/pages/home_page.dart';
 import '../notifiers/auth_state_notifier.dart';
+import 'confirmation_page.dart';
 
 class CreateProfilePage extends ConsumerStatefulWidget {
-  const CreateProfilePage({super.key});
+  final String email;
+  const CreateProfilePage({super.key, required this.email});
 
   @override
   ConsumerState<CreateProfilePage> createState() => _CreateProfilePageState();
@@ -15,13 +16,14 @@ class CreateProfilePage extends ConsumerStatefulWidget {
 class _CreateProfilePageState extends ConsumerState<CreateProfilePage> {
   final _formKey = GlobalKey<FormState>();
   final _usernameController = TextEditingController();
+  final _passwordController = TextEditingController();
   final _bioController = TextEditingController();
   final _twitterController = TextEditingController();
-  bool _isLoading = false;
 
   @override
   void dispose() {
     _usernameController.dispose();
+    _passwordController.dispose();
     _bioController.dispose();
     _twitterController.dispose();
     super.dispose();
@@ -31,39 +33,37 @@ class _CreateProfilePageState extends ConsumerState<CreateProfilePage> {
     if (!_formKey.currentState!.validate()) {
       return;
     }
-    setState(() => _isLoading = true);
-
+    
     final notifier = ref.read(authStateNotifierProvider.notifier);
-    // setupProfileメソッドを新しい引数で呼び出す（auth_state_notifier.dartの修正も必要）
-    final success = await notifier.setupProfile(
+    await notifier.createProfileAndSignUp(
+      email: widget.email,
+      password: _passwordController.text,
       username: _usernameController.text,
       bio: _bioController.text,
       twitterId: _twitterController.text,
     );
-
-    if (mounted) {
-      if (!success) {
-        setState(() => _isLoading = false);
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('プロフィールの設定に失敗しました。')),
-        );
-      }
-    }
   }
 
   @override
   Widget build(BuildContext context) {
     ref.listen(authStateNotifierProvider, (_, next) {
-      if (next.status == AuthStatus.authenticated) {
-        Navigator.of(context).pushAndRemoveUntil(
-          MaterialPageRoute(builder: (_) => const HomePage()),
-          (route) => false,
+      if (next.status == AuthStatus.confirmationRequired) {
+        Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (_) => ConfirmationPage(username: next.usernameForConfirmation!),
+          ),
+        );
+      } else if (next.status == AuthStatus.error) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('登録エラー: ${next.errorMessage}')),
         );
       }
     });
 
+    final authState = ref.watch(authStateNotifierProvider);
+
     return Scaffold(
-      appBar: AppBar(title: const Text('プロフィールを設定')),
+      appBar: AppBar(title: const Text('プロフィールとパスワードを設定')),
       body: SingleChildScrollView(
         padding: const EdgeInsets.all(16.0),
         child: Form(
@@ -71,12 +71,7 @@ class _CreateProfilePageState extends ConsumerState<CreateProfilePage> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              Text(
-                'ようこそ！',
-                style: Theme.of(context).textTheme.headlineMedium,
-              ),
-              const SizedBox(height: 8),
-              const Text('他のユーザーに表示される情報を設定してください。'),
+              const Text('次に、プロフィール情報とパスワードを設定します。'),
               const SizedBox(height: 24),
               TextFormField(
                 controller: _usernameController,
@@ -87,6 +82,21 @@ class _CreateProfilePageState extends ConsumerState<CreateProfilePage> {
                 validator: (value) {
                   if (value == null || value.trim().isEmpty) {
                     return 'ユーザー名は必須です';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16.0),
+              TextFormField(
+                controller: _passwordController,
+                obscureText: true,
+                decoration: const InputDecoration(
+                  labelText: 'パスワード (8文字以上) *',
+                  border: OutlineInputBorder(),
+                ),
+                validator: (value) {
+                  if (value == null || value.length < 8) {
+                    return 'パスワードは8文字以上で入力してください';
                   }
                   return null;
                 },
@@ -113,11 +123,11 @@ class _CreateProfilePageState extends ConsumerState<CreateProfilePage> {
               ),
               const SizedBox(height: 24.0),
               ElevatedButton(
-                onPressed: _isLoading ? null : _onSaveProfile,
+                onPressed: authState.status == AuthStatus.loading ? null : _onSaveProfile,
                 style: ElevatedButton.styleFrom(
                   padding: const EdgeInsets.symmetric(vertical: 16.0),
                 ),
-                child: _isLoading
+                child: authState.status == AuthStatus.loading
                     ? const SizedBox(
                         height: 24,
                         width: 24,

--- a/lib/features/auth/presentation/pages/create_profile_page.dart
+++ b/lib/features/auth/presentation/pages/create_profile_page.dart
@@ -48,6 +48,11 @@ class _CreateProfilePageState extends ConsumerState<CreateProfilePage> {
   Widget build(BuildContext context) {
     ref.listen(authStateNotifierProvider, (_, next) {
       if (next.status == AuthStatus.confirmationRequired) {
+                if (next.errorMessage != null && next.errorMessage!.isNotEmpty) {
+           ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(next.errorMessage!)),
+          );
+        }
         Navigator.of(context).push(
           MaterialPageRoute(
             builder: (_) => ConfirmationPage(

--- a/lib/features/auth/presentation/pages/create_profile_page.dart
+++ b/lib/features/auth/presentation/pages/create_profile_page.dart
@@ -50,7 +50,10 @@ class _CreateProfilePageState extends ConsumerState<CreateProfilePage> {
       if (next.status == AuthStatus.confirmationRequired) {
         Navigator.of(context).push(
           MaterialPageRoute(
-            builder: (_) => ConfirmationPage(username: next.usernameForConfirmation!),
+            builder: (_) => ConfirmationPage(
+              username: next.usernameForConfirmation!,
+              password: _passwordController.text,
+            ),
           ),
         );
       } else if (next.status == AuthStatus.error) {

--- a/lib/features/auth/presentation/pages/login_page.dart
+++ b/lib/features/auth/presentation/pages/login_page.dart
@@ -4,7 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:my_madamis_app/features/home/presentation/pages/home_page.dart';
 import '../notifiers/auth_state_notifier.dart';
-import 'forgot_password_page.dart'; // 追加
+import 'confirmation_page.dart';
+import 'forgot_password_page.dart';
 import 'signup_page.dart';
 
 class LoginPage extends ConsumerWidget {
@@ -21,6 +22,16 @@ class LoginPage extends ConsumerWidget {
         Navigator.of(context).pushReplacement(
           MaterialPageRoute(builder: (_) => const HomePage()),
         );
+      } else if (next.status == AuthStatus.confirmationRequired) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(next.errorMessage ?? 'アカウントの確認が必要です。')),
+        );
+        Navigator.of(context).push(MaterialPageRoute(
+          builder: (_) => ConfirmationPage(
+            username: next.usernameForConfirmation!,
+            password: passwordController.text,
+          ),
+        ));
       }
     });
 
@@ -29,7 +40,6 @@ class LoginPage extends ConsumerWidget {
       body: Padding(
         padding: const EdgeInsets.all(20.0),
         child: Column(
-          // ... (変更なし) ...
           children: [
             TextFormField(controller: emailController, decoration: const InputDecoration(labelText: 'メールアドレス')),
             const SizedBox(height: 12),
@@ -48,7 +58,6 @@ class LoginPage extends ConsumerWidget {
                 child: Text('エラー: ${authState.errorMessage}', style: const TextStyle(color: Colors.red)),
               ),
             TextButton(
-              // onPressedのコメントアウトを解除し、ナビゲーションを追加
               onPressed: () {
                 Navigator.push(context, MaterialPageRoute(builder: (_) => const ForgotPasswordPage()));
               },

--- a/lib/features/auth/presentation/pages/signup_page.dart
+++ b/lib/features/auth/presentation/pages/signup_page.dart
@@ -10,7 +10,6 @@ class SignUpPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // ▼▼▼ usernameController を削除 ▼▼▼
     final usernameController = TextEditingController();
     final emailController = TextEditingController();
     final passwordController = TextEditingController();
@@ -30,15 +29,14 @@ class SignUpPage extends ConsumerWidget {
         padding: const EdgeInsets.all(20.0),
         child: Column(
           children: [
-            // ▼▼▼ ユーザー名のTextFormFieldを削除 ▼▼▼
+            TextFormField(controller: usernameController, decoration: const InputDecoration(labelText: 'ユーザー名')),
             TextFormField(controller: emailController, decoration: const InputDecoration(labelText: 'メールアドレス')),
-            TextFormField(controller: passwordController, obscureText: true, decoration: const InputDecoration(labelText: 'パスワード')),
+            TextFormField(controller: passwordController, obscureText: true, decoration: const InputDecoration(labelText: 'パスワード (8文字以上)')),
             const SizedBox(height: 20),
              if (authState.status == AuthStatus.loading)
               const Center(child: CircularProgressIndicator())
             else
               ElevatedButton(
-                // ▼▼▼ signUpの引数からusernameController.textを削除 ▼▼▼
                 onPressed: () => ref.read(authStateNotifierProvider.notifier).signUp(
                       usernameController.text,
                       passwordController.text,

--- a/lib/features/auth/presentation/pages/signup_page.dart
+++ b/lib/features/auth/presentation/pages/signup_page.dart
@@ -10,7 +10,7 @@ class SignUpPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final usernameController = TextEditingController();
+    // ▼▼▼ usernameController を削除 ▼▼▼
     final emailController = TextEditingController();
     final passwordController = TextEditingController();
     final authState = ref.watch(authStateNotifierProvider);
@@ -29,7 +29,7 @@ class SignUpPage extends ConsumerWidget {
         padding: const EdgeInsets.all(20.0),
         child: Column(
           children: [
-            TextFormField(controller: usernameController, decoration: const InputDecoration(labelText: 'ユーザー名')),
+            // ▼▼▼ ユーザー名のTextFormFieldを削除 ▼▼▼
             TextFormField(controller: emailController, decoration: const InputDecoration(labelText: 'メールアドレス')),
             TextFormField(controller: passwordController, obscureText: true, decoration: const InputDecoration(labelText: 'パスワード (8文字以上)')),
             const SizedBox(height: 20),
@@ -37,8 +37,8 @@ class SignUpPage extends ConsumerWidget {
               const Center(child: CircularProgressIndicator())
             else
               ElevatedButton(
+                // ▼▼▼ signUpの引数からusernameController.textを削除 ▼▼▼
                 onPressed: () => ref.read(authStateNotifierProvider.notifier).signUp(
-                      usernameController.text,
                       passwordController.text,
                       emailController.text,
                     ),

--- a/lib/features/auth/presentation/pages/signup_page.dart
+++ b/lib/features/auth/presentation/pages/signup_page.dart
@@ -2,54 +2,69 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import '../notifiers/auth_state_notifier.dart';
-import 'confirmation_page.dart';
+import 'create_profile_page.dart';
 
-class SignUpPage extends ConsumerWidget {
+class SignUpPage extends ConsumerStatefulWidget {
   const SignUpPage({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    // ▼▼▼ usernameController を削除 ▼▼▼
-    final emailController = TextEditingController();
-    final passwordController = TextEditingController();
-    final authState = ref.watch(authStateNotifierProvider);
+  ConsumerState<SignUpPage> createState() => _SignUpPageState();
+}
 
-    ref.listen(authStateNotifierProvider, (_, next) {
-      if (next.status == AuthStatus.confirmationRequired) {
-        Navigator.push(context, MaterialPageRoute(
-          builder: (_) => ConfirmationPage(username: next.usernameForConfirmation!),
-        ));
-      }
-    });
+class _SignUpPageState extends ConsumerState<SignUpPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _emailController = TextEditingController();
 
+  @override
+  void dispose() {
+    _emailController.dispose();
+    super.dispose();
+  }
+
+  void _goToNextStep() {
+    if (_formKey.currentState!.validate()) {
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (_) => CreateProfilePage(email: _emailController.text),
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('ユーザー登録')),
+      appBar: AppBar(title: const Text('新規登録')),
       body: Padding(
         padding: const EdgeInsets.all(20.0),
-        child: Column(
-          children: [
-            // ▼▼▼ ユーザー名のTextFormFieldを削除 ▼▼▼
-            TextFormField(controller: emailController, decoration: const InputDecoration(labelText: 'メールアドレス')),
-            TextFormField(controller: passwordController, obscureText: true, decoration: const InputDecoration(labelText: 'パスワード (8文字以上)')),
-            const SizedBox(height: 20),
-             if (authState.status == AuthStatus.loading)
-              const Center(child: CircularProgressIndicator())
-            else
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              const Text('まず、メールアドレスを登録してください。'),
+              const SizedBox(height: 20),
+              TextFormField(
+                controller: _emailController,
+                decoration: const InputDecoration(
+                  labelText: 'メールアドレス',
+                  border: OutlineInputBorder(),
+                ),
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty || !value.contains('@')) {
+                    return '有効なメールアドレスを入力してください';
+                  }
+                  return null;
+                },
+                keyboardType: TextInputType.emailAddress,
+              ),
+              const SizedBox(height: 24),
               ElevatedButton(
-                // ▼▼▼ signUpの引数からusernameController.textを削除 ▼▼▼
-                onPressed: () => ref.read(authStateNotifierProvider.notifier).signUp(
-                      passwordController.text,
-                      emailController.text,
-                    ),
-                child: const Text('登録'),
+                onPressed: _goToNextStep,
+                child: const Text('次へ'),
               ),
-            if (authState.status == AuthStatus.error)
-              Padding(
-                padding: const EdgeInsets.only(top: 8.0),
-                child: Text('エラー: ${authState.errorMessage}', style: const TextStyle(color: Colors.red)),
-              ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/profile/presentation/notifiers/profile_state_notifier.dart
+++ b/lib/features/profile/presentation/notifiers/profile_state_notifier.dart
@@ -3,20 +3,16 @@
 import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:my_madamis_app/features/auth/data/auth_repository.dart';
-// --- ▼▼▼ ここから追加 ▼▼▼ ---
 import 'package:my_madamis_app/features/auth/presentation/notifiers/auth_state_notifier.dart';
-// --- ▲▲▲ ここまで追加 ▲▲▲ ---
 
-// プロフィール画面の状態
 enum ProfileStatus { loading, loaded, error }
-// 保存処理の状態
 enum UpdateStatus { initial, success, error }
 
-// 状態管理クラス
 class ProfileState {
   final ProfileStatus status;
   final String? username;
   final String? bio;
+  final String? twitterId; // 追加
   final String? errorMessage;
   final UpdateStatus updateStatus;
 
@@ -24,6 +20,7 @@ class ProfileState {
     this.status = ProfileStatus.loading,
     this.username,
     this.bio,
+    this.twitterId, // 追加
     this.errorMessage,
     this.updateStatus = UpdateStatus.initial,
   });
@@ -32,6 +29,7 @@ class ProfileState {
     ProfileStatus? status,
     String? username,
     String? bio,
+    String? twitterId, // 追加
     String? errorMessage,
     UpdateStatus? updateStatus,
   }) {
@@ -39,33 +37,26 @@ class ProfileState {
       status: status ?? this.status,
       username: username ?? this.username,
       bio: bio ?? this.bio,
+      twitterId: twitterId ?? this.twitterId, // 追加
       errorMessage: errorMessage ?? this.errorMessage,
       updateStatus: updateStatus ?? this.updateStatus,
     );
   }
 }
 
-// StateNotifierProvider
-// --- ▼▼▼ ここから修正 ▼▼▼ ---
 final profileStateNotifierProvider =
     StateNotifierProvider<ProfileStateNotifier, ProfileState>((ref) {
   return ProfileStateNotifier(ref)..loadCurrentUser();
 });
-// --- ▲▲▲ ここまで修正 ▲▲▲ ---
 
-
-// StateNotifier
 class ProfileStateNotifier extends StateNotifier<ProfileState> {
-  // --- ▼▼▼ ここから修正 ▼▼▼ ---
   final Ref _ref;
   late final AuthRepository _authRepository;
 
   ProfileStateNotifier(this._ref) : super(const ProfileState()) {
     _authRepository = _ref.read(authRepositoryProvider);
   }
-  // --- ▲▲▲ ここまで修正 ▲▲▲ ---
 
-  /// ログイン後、最初にユーザー情報を読み込みます。
   Future<void> loadCurrentUser() async {
     try {
       state = state.copyWith(status: ProfileStatus.loading);
@@ -73,11 +64,13 @@ class ProfileStateNotifier extends StateNotifier<ProfileState> {
       
       final username = attributes[AuthUserAttributeKey.preferredUsername];
       final bio = attributes[const CognitoUserAttributeKey.custom('bio')];
+      final twitterId = attributes[const CognitoUserAttributeKey.custom('twitter_id')]; // 追加
 
       state = state.copyWith(
         status: ProfileStatus.loaded,
         username: username,
         bio: bio,
+        twitterId: twitterId, // 追加
       );
     } catch (e) {
       state = state.copyWith(
@@ -87,24 +80,23 @@ class ProfileStateNotifier extends StateNotifier<ProfileState> {
     }
   }
 
-  /// プロフィール情報を更新します。
-  // --- ▼▼▼ ここから修正 ▼▼▼ ---
   Future<bool> updateProfile({
     required String username,
     required String bio,
+    required String twitterId, // 追加
   }) async {
     try {
       await _authRepository.updateUserAttributes(
         username: username,
         bio: bio,
+        twitterId: twitterId, // 追加
       );
-      // AuthStateNotifierのユーザー名も更新してUIを同期
       _ref.read(authStateNotifierProvider.notifier).updateUsername(username);
       
-      // 現在のNotifierの状態を更新
       state = state.copyWith(
         username: username,
         bio: bio,
+        twitterId: twitterId, // 追加
         updateStatus: UpdateStatus.success,
       );
       return true;
@@ -113,9 +105,7 @@ class ProfileStateNotifier extends StateNotifier<ProfileState> {
       return false;
     }
   }
-  // --- ▲▲▲ ここまで修正 ▲▲▲ ---
 
-  /// 更新後のメッセージ表示を一度だけに限定するため、ステータスをリセットします。
   void resetUpdateStatus() {
     state = state.copyWith(updateStatus: UpdateStatus.initial);
   }

--- a/lib/features/profile/presentation/pages/edit_profile_page.dart
+++ b/lib/features/profile/presentation/pages/edit_profile_page.dart
@@ -15,27 +15,27 @@ class _EditProfilePageState extends ConsumerState<EditProfilePage> {
   final _formKey = GlobalKey<FormState>();
   late final TextEditingController _usernameController;
   late final TextEditingController _bioController;
+  late final TextEditingController _twitterController; // 追加
   bool _isLoading = false;
 
   @override
   void initState() {
     super.initState();
-    // 現在の状態をProviderから読み込んで初期値として設定
     final profileState = ref.read(profileStateNotifierProvider);
     _usernameController = TextEditingController(text: profileState.username);
     _bioController = TextEditingController(text: profileState.bio);
+    _twitterController = TextEditingController(text: profileState.twitterId); // 追加
   }
 
   @override
   void dispose() {
     _usernameController.dispose();
     _bioController.dispose();
+    _twitterController.dispose(); // 追加
     super.dispose();
   }
 
-  // 保存ボタンが押されたときの処理
   Future<void> _onSave() async {
-    // バリデーションチェック
     if (!_formKey.currentState!.validate()) {
       return;
     }
@@ -45,12 +45,12 @@ class _EditProfilePageState extends ConsumerState<EditProfilePage> {
     final success = await notifier.updateProfile(
       username: _usernameController.text,
       bio: _bioController.text,
+      twitterId: _twitterController.text, // 追加
     );
 
-    // このウィジェットが画面上に存在するかを確認
     if (mounted) {
       if (success) {
-        Navigator.of(context).pop(); // 成功したらプロフィール画面に戻る
+        Navigator.of(context).pop();
       } else {
         setState(() => _isLoading = false);
         ScaffoldMessenger.of(context).showSnackBar(
@@ -96,6 +96,15 @@ class _EditProfilePageState extends ConsumerState<EditProfilePage> {
                 ),
                 maxLines: 5,
                 maxLength: 200,
+              ),
+              const SizedBox(height: 16.0),
+              TextFormField( // 追加
+                controller: _twitterController,
+                decoration: const InputDecoration(
+                  labelText: 'X (Twitter) ID',
+                  border: OutlineInputBorder(),
+                  prefixText: '@',
+                ),
               ),
               const SizedBox(height: 24.0),
               ElevatedButton.icon(

--- a/lib/features/profile/presentation/pages/profile_page.dart
+++ b/lib/features/profile/presentation/pages/profile_page.dart
@@ -10,7 +10,6 @@ class ProfilePage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // 編集画面から戻ってきた際の更新成功メッセージ表示を監視
     ref.listen(profileStateNotifierProvider, (previous, next) {
       if (next.updateStatus == UpdateStatus.success) {
         ScaffoldMessenger.of(context).showSnackBar(
@@ -19,7 +18,6 @@ class ProfilePage extends ConsumerWidget {
             behavior: SnackBarBehavior.floating,
           ),
         );
-        // メッセージ表示後にステータスをリセット
         ref.read(profileStateNotifierProvider.notifier).resetUpdateStatus();
       }
     });
@@ -60,6 +58,15 @@ class ProfilePage extends ConsumerWidget {
                         : '自己紹介が設定されていません。',
                     style: Theme.of(context).textTheme.bodyLarge,
                   ),
+                  const SizedBox(height: 24),
+                  _buildSectionTitle('X (Twitter)'),
+                  const SizedBox(height: 8),
+                  Text(
+                    profileState.twitterId != null && profileState.twitterId!.isNotEmpty
+                        ? '@${profileState.twitterId!}'
+                        : 'X IDが設定されていません。',
+                    style: Theme.of(context).textTheme.bodyLarge,
+                  ),
                 ],
               ),
             ),
@@ -69,7 +76,8 @@ class ProfilePage extends ConsumerWidget {
   }
   
   Widget _buildProfileHeader(BuildContext context, ProfileState state) {
-    return Row(
+    // ... (変更なし) ...
+        return Row(
       children: [
         Container(
           padding: const EdgeInsets.all(20),
@@ -96,6 +104,7 @@ class ProfilePage extends ConsumerWidget {
   }
 
   Widget _buildSectionTitle(String title) {
+    // ... (変更なし) ...
     return Text(
       title,
       style: const TextStyle(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,11 +8,8 @@ import 'amplifyconfiguration.dart';
 import 'features/auth/presentation/pages/login_page.dart';
 
 Future<void> main() async {
-  // Flutterアプリの初期化
   WidgetsFlutterBinding.ensureInitialized();
-  // Amplifyの設定
   await _configureAmplify();
-  // アプリの実行
   runApp(
     const ProviderScope(
       child: MyApp(),
@@ -22,11 +19,8 @@ Future<void> main() async {
 
 Future<void> _configureAmplify() async {
   try {
-    // Authプラグインを追加
     final auth = AmplifyAuthCognito();
     await Amplify.addPlugin(auth);
-
-    // Amplifyを設定
     await Amplify.configure(amplifyconfig);
     safePrint('Amplify configured successfully');
   } on Exception catch (e) {
@@ -35,7 +29,10 @@ Future<void> _configureAmplify() async {
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+  // ▼▼▼ 以下を追加 ▼▼▼
+  final Widget? home;
+  const MyApp({super.key, this.home});
+  // ▲▲▲ ここまで追加 ▲▲▲
 
   @override
   Widget build(BuildContext context) {
@@ -45,7 +42,9 @@ class MyApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
-      home: const LoginPage(), // 開始画面をログイン画面に設定
+      // ▼▼▼ 以下を修正 ▼▼▼
+      home: home ?? const LoginPage(),
+      // ▲▲▲ ここまで修正 ▲▲▲
     );
   }
 }

--- a/test/features/auth/presentation/pages/signup_flow_test.dart
+++ b/test/features/auth/presentation/pages/signup_flow_test.dart
@@ -1,0 +1,238 @@
+// ファイルパス: test/features/auth/presentation/pages/signup_flow_test.dart
+
+import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:my_madamis_app/features/auth/data/auth_repository.dart';
+import 'package:my_madamis_app/features/auth/presentation/pages/confirmation_page.dart';
+import 'package:my_madamis_app/features/auth/presentation/pages/create_profile_page.dart';
+import 'package:my_madamis_app/features/auth/presentation/pages/login_page.dart';
+import 'package:my_madamis_app/features/auth/presentation/pages/signup_page.dart';
+import 'package:my_madamis_app/features/home/presentation/pages/home_page.dart';
+import 'package:my_madamis_app/main.dart' as app;
+
+import '../../../../mocks.mocks.dart';
+
+// main.dartのMyAppにアクセスするためのヘルパー
+class TestApp extends app.MyApp {
+  const TestApp({super.key, required Widget home}) : super(home: home);
+}
+
+void main() {
+  late MockAuthRepository mockAuthRepository;
+
+  // テストウィジェットをラップするヘルパー
+  Widget createTestApp({required Widget home}) {
+    return ProviderScope(
+      overrides: [
+        authRepositoryProvider.overrideWithValue(mockAuthRepository),
+      ],
+      child: TestApp(home: home),
+    );
+  }
+
+  // 各テストの前にMockを初期化
+  setUp(() {
+    mockAuthRepository = MockAuthRepository();
+  });
+
+  group('新規登録フロー ウィジェットテスト', () {
+    const testEmail = 'new_user@example.com';
+    const testPassword = 'password123';
+    const testUsername = 'New User';
+    const testConfirmationCode = '123456';
+
+    // 正常なサインアップ処理のモックをセットアップするヘルパー
+    void setupSuccessfulSignUpMocks() {
+      // 1. サインアップ処理
+      when(mockAuthRepository.signUpWithProfile(
+        email: anyNamed('email'),
+        password: anyNamed('password'),
+        username: anyNamed('username'),
+        bio: anyNamed('bio'),
+        twitterId: anyNamed('twitterId'),
+      )).thenAnswer((_) async => const SignUpResult(
+            isSignUpComplete: false, // 確認コードが必要な状態
+            nextStep: AuthNextSignUpStep(
+              signUpStep: AuthSignUpStep.confirmSignUp,
+            ),
+          ));
+
+      // 2. 確認コード認証
+      // ▼▼▼ `nextStep` に正しい値を設定 ▼▼▼
+      when(mockAuthRepository.confirmSignUp(
+        username: anyNamed('username'),
+        confirmationCode: anyNamed('confirmationCode'),
+      )).thenAnswer((_) async => const SignUpResult(
+            isSignUpComplete: true,
+            nextStep: AuthNextSignUpStep(signUpStep: AuthSignUpStep.done),
+          ));
+      
+      // 3. 自動サインイン
+      when(mockAuthRepository.signIn(
+        username: anyNamed('username'),
+        password: anyNamed('password'),
+      )).thenAnswer((_) async => const SignInResult(
+            isSignedIn: true,
+            nextStep: AuthNextSignInStep(signInStep: AuthSignInStep.done),
+          ));
+      
+      // 4. ユーザー属性の取得
+      when(mockAuthRepository.fetchUserAttributes()).thenAnswer((_) async => [
+            const AuthUserAttribute(
+                userAttributeKey: AuthUserAttributeKey.preferredUsername,
+                value: testUsername)
+          ]);
+    }
+
+    testWidgets('[SIGNUP-FLOW-001] 全項目を入力して正常に登録完了し、ホーム画面に遷移する',
+        (tester) async {
+      setupSuccessfulSignUpMocks();
+
+      // --- 実行 ---
+      await tester.pumpWidget(createTestApp(home: const LoginPage()));
+      
+      // 1. ログイン画面から新規登録画面へ
+      await tester.tap(find.widgetWithText(OutlinedButton, '新規登録'));
+      await tester.pumpAndSettle();
+      expect(find.byType(SignUpPage), findsOneWidget);
+
+      // 2. メールアドレスを入力してプロフィール作成画面へ
+      await tester.enterText(find.byType(TextFormField), testEmail);
+      await tester.tap(find.widgetWithText(ElevatedButton, '次へ'));
+      await tester.pumpAndSettle();
+      expect(find.byType(CreateProfilePage), findsOneWidget);
+
+      // 3. プロフィールとパスワードを入力して「利用を開始する」
+      await tester.enterText(find.widgetWithText(TextFormField, 'ユーザー名 *'), testUsername);
+      await tester.enterText(find.widgetWithText(TextFormField, 'パスワード (8文字以上) *'), testPassword);
+      await tester.enterText(find.widgetWithText(TextFormField, '自己紹介 (任意)'), 'Hello!');
+      await tester.enterText(find.widgetWithText(TextFormField, 'X (Twitter) ID (任意)'), 'flutterdev');
+      await tester.tap(find.widgetWithText(ElevatedButton, '利用を開始する'));
+      await tester.pumpAndSettle();
+      expect(find.byType(ConfirmationPage), findsOneWidget);
+
+      // 4. 確認コードを入力して認証
+      await tester.enterText(find.widgetWithText(TextFormField, '認証コード'), testConfirmationCode);
+      await tester.tap(find.widgetWithText(ElevatedButton, '認証'));
+      await tester.pumpAndSettle();
+
+      // --- 検証 ---
+      expect(find.byType(HomePage), findsOneWidget);
+      expect(find.text('ようこそ！$testUsernameさん！ログインに成功しました。'), findsOneWidget);
+    });
+    
+    testWidgets('[SIGNUP-FLOW-002] 任意項目を空で正常に登録完了し、ホーム画面に遷移する',
+        (tester) async {
+      setupSuccessfulSignUpMocks();
+
+      // --- 実行 ---
+      await tester.pumpWidget(createTestApp(home: const LoginPage()));
+      await tester.tap(find.widgetWithText(OutlinedButton, '新規登録'));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextFormField), testEmail);
+      await tester.tap(find.widgetWithText(ElevatedButton, '次へ'));
+      await tester.pumpAndSettle();
+
+      // 任意項目は入力しない
+      await tester.enterText(find.widgetWithText(TextFormField, 'ユーザー名 *'), testUsername);
+      await tester.enterText(find.widgetWithText(TextFormField, 'パスワード (8文字以上) *'), testPassword);
+      await tester.tap(find.widgetWithText(ElevatedButton, '利用を開始する'));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.widgetWithText(TextFormField, '認証コード'), testConfirmationCode);
+      await tester.tap(find.widgetWithText(ElevatedButton, '認証'));
+      await tester.pumpAndSettle();
+
+      // --- 検証 ---
+      expect(find.byType(HomePage), findsOneWidget);
+    });
+
+    testWidgets('[SIGNUP-FLOW-003] 登録済みのメールアドレスで登録しようとすると、コード再送の案内が出て確認画面に遷移する',
+        (tester) async {
+      // 登録済みユーザーエラーを返すようにモックを設定
+      when(mockAuthRepository.signUpWithProfile(
+        email: anyNamed('email'),
+        password: anyNamed('password'),
+        username: anyNamed('username'),
+        bio: anyNamed('bio'),
+        twitterId: anyNamed('twitterId'),
+      )).thenThrow(const UsernameExistsException( 'User already exists'));
+      
+      // コード再送は成功させる
+      when(mockAuthRepository.resendSignUpCode(username: anyNamed('username')))
+          .thenAnswer((_) async {});
+      
+      // --- 実行 ---
+      await tester.pumpWidget(createTestApp(home: const SignUpPage()));
+      await tester.enterText(find.byType(TextFormField), testEmail);
+      await tester.tap(find.widgetWithText(ElevatedButton, '次へ'));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.widgetWithText(TextFormField, 'ユーザー名 *'), testUsername);
+      await tester.enterText(find.widgetWithText(TextFormField, 'パスワード (8文字以上) *'), testPassword);
+      await tester.tap(find.widgetWithText(ElevatedButton, '利用を開始する'));
+      await tester.pumpAndSettle();
+
+      // --- 検証 ---
+      expect(find.byType(ConfirmationPage), findsOneWidget);
+      expect(find.text('このメールアドレスは登録済みです。確認コードを再送信しました。'), findsOneWidget);
+    });
+
+    testWidgets('[SIGNUP-FLOW-004] 未確認ユーザーがログインしようとすると、コード再送の案内が出て確認画面に遷移する',
+        (tester) async {
+      // 未確認ユーザーエラーを返すようにモックを設定
+      when(mockAuthRepository.signIn(
+        username: anyNamed('username'),
+        password: anyNamed('password'),
+      )).thenThrow(const UserNotConfirmedException( 'User is not confirmed.'));
+      
+      // コード再送は成功させる
+      when(mockAuthRepository.resendSignUpCode(username: anyNamed('username')))
+          .thenAnswer((_) async {});
+      
+      // --- 実行 ---
+      await tester.pumpWidget(createTestApp(home: const LoginPage()));
+      await tester.enterText(find.widgetWithText(TextFormField, 'メールアドレス'), testEmail);
+      await tester.enterText(find.widgetWithText(TextFormField, 'パスワード'), testPassword);
+      await tester.tap(find.widgetWithText(ElevatedButton, 'ログイン'));
+      await tester.pumpAndSettle();
+      
+      // --- 検証 ---
+      expect(find.byType(ConfirmationPage), findsOneWidget);
+      expect(find.text('このアカウントは未確認です。確認コードをメールアドレスに送信しました。'), findsOneWidget);
+    });
+
+    testWidgets('[SIGNUP-FLOW-005] 確認コードを間違えるとエラーメッセージが表示される',
+        (tester) async {
+      setupSuccessfulSignUpMocks();
+      // 確認コードのモックのみ上書き
+      when(mockAuthRepository.confirmSignUp(
+        username: anyNamed('username'),
+        confirmationCode: 'wrong-code',
+      )).thenThrow(const CodeMismatchException('Invalid code'));
+
+      // --- 実行 ---
+      await tester.pumpWidget(createTestApp(home: const SignUpPage()));
+      await tester.enterText(find.byType(TextFormField), testEmail);
+      await tester.tap(find.widgetWithText(ElevatedButton, '次へ'));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.widgetWithText(TextFormField, 'ユーザー名 *'), testUsername);
+      await tester.enterText(find.widgetWithText(TextFormField, 'パスワード (8文字以上) *'), testPassword);
+      await tester.tap(find.widgetWithText(ElevatedButton, '利用を開始する'));
+      await tester.pumpAndSettle();
+      
+      await tester.enterText(find.widgetWithText(TextFormField, '認証コード'), 'wrong-code');
+      await tester.tap(find.widgetWithText(ElevatedButton, '認証'));
+      await tester.pumpAndSettle();
+
+      // --- 検証 ---
+      expect(find.byType(ConfirmationPage), findsOneWidget); // 画面はそのまま
+      expect(find.byType(HomePage), findsNothing);
+      expect(find.textContaining('エラー: 認証に失敗しました'), findsOneWidget);
+    });
+  });
+}
+

--- a/test/features/profile/presentation/notifiers/profile_state_notifier_test.dart
+++ b/test/features/profile/presentation/notifiers/profile_state_notifier_test.dart
@@ -86,15 +86,16 @@ void main() {
     test('[PROFILE-NOTIFIER-003] updateProfile - 成功時にrepositoryが呼ばれ、状態が更新される', () async {
       const newUsername = 'new_username';
       const newBio = 'new_bio';
+      const newtwitterId = 'new_twitterId';
 
-      when(mockAuthRepository.updateUserAttributes(username: newUsername, bio: newBio))
+      when(mockAuthRepository.updateUserAttributes(username: newUsername, bio: newBio,twitterId: newtwitterId))
           .thenAnswer((_) async {});
 
       final notifier = container.read(profileStateNotifierProvider.notifier);
-      final success = await notifier.updateProfile(username: newUsername, bio: newBio);
+      final success = await notifier.updateProfile(username: newUsername, bio: newBio,twitterId: newtwitterId);
 
       expect(success, isTrue);
-      verify(mockAuthRepository.updateUserAttributes(username: newUsername, bio: newBio)).called(1);
+      verify(mockAuthRepository.updateUserAttributes(username: newUsername, bio: newBio,twitterId: newtwitterId)).called(1);
       
       final state = container.read(profileStateNotifierProvider);
       expect(state.username, newUsername);
@@ -105,12 +106,13 @@ void main() {
     test('[PROFILE-NOTIFIER-004] updateProfile - 失敗時にerror状態になり、falseが返される', () async {
       const newUsername = 'new_username';
       const newBio = 'new_bio';
+      const newtwitterId = 'new_twitterId';
       final exception = Exception('Failed to update profile');
-      when(mockAuthRepository.updateUserAttributes(username: newUsername, bio: newBio))
+      when(mockAuthRepository.updateUserAttributes(username: newUsername, bio: newBio,twitterId: newtwitterId))
           .thenThrow(exception);
 
       final notifier = container.read(profileStateNotifierProvider.notifier);
-      final success = await notifier.updateProfile(username: newUsername, bio: newBio);
+      final success = await notifier.updateProfile(username: newUsername, bio: newBio,twitterId: newtwitterId);
 
       expect(success, isFalse);
 

--- a/test/features/profile/presentation/pages/profile_flow_test.dart
+++ b/test/features/profile/presentation/pages/profile_flow_test.dart
@@ -14,7 +14,6 @@ import '../../../../mocks.mocks.dart';
 void main() {
   late MockAuthRepository mockAuthRepository;
 
-  // テスト対象のWidgetとMockをProviderScopeでラップするヘルパー
   Widget createTestApp(Widget child) {
     return ProviderScope(
       overrides: [
@@ -28,12 +27,16 @@ void main() {
     mockAuthRepository = MockAuthRepository();
   });
 
+  // --- ▼▼▼ ここから修正 ▼▼▼ ---
   const initialUsername = 'initial_user';
   const initialBio = 'Initial bio text.';
+  const initialTwitterId = 'initial_twitter'; // 初期Twitter IDを追加
   final initialAttributes = {
     AuthUserAttributeKey.preferredUsername: initialUsername,
     const CognitoUserAttributeKey.custom('bio'): initialBio,
+    const CognitoUserAttributeKey.custom('twitter_id'): initialTwitterId, // 初期データを追加
   };
+  // --- ▲▲▲ ここまで修正 ▲▲▲ ---
 
   group('Profile Flow Widget Tests', () {
     testWidgets('[PROFILE-WIDGET-001] ProfilePage - ユーザー情報が正しく表示される', (tester) async {
@@ -42,13 +45,14 @@ void main() {
 
       await tester.pumpWidget(createTestApp(const ProfilePage()));
       
-      // ローディング表示を確認
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
-      await tester.pumpAndSettle(); // 非同期処理の完了を待つ
+      await tester.pumpAndSettle();
 
-      // データが表示されたことを確認
       expect(find.text(initialUsername), findsOneWidget);
       expect(find.text(initialBio), findsOneWidget);
+      // --- ▼▼▼ ここから追加 ▼▼▼ ---
+      expect(find.text('@$initialTwitterId'), findsOneWidget); // 表示を検証
+      // --- ▲▲▲ ここまで追加 ▲▲▲ ---
       expect(find.byType(CircularProgressIndicator), findsNothing);
     });
 
@@ -63,45 +67,48 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byType(EditProfilePage), findsOneWidget);
-      // 編集画面のフィールドに初期値が設定されていることを確認
       expect(find.widgetWithText(TextFormField, initialUsername), findsOneWidget);
       expect(find.widgetWithText(TextFormField, initialBio), findsOneWidget);
+      // --- ▼▼▼ ここから追加 ▼▼▼ ---
+      expect(find.widgetWithText(TextFormField, initialTwitterId), findsOneWidget); // フィールドを検証
+      // --- ▲▲▲ ここまで追加 ▲▲▲ ---
     });
     
     testWidgets('[PROFILE-WIDGET-003] EditProfilePage - プロフィール更新の正常系フロー', (tester) async {
       const newUsername = 'new_username';
       const newBio = 'Updated bio text!';
+      const newTwitterId = 'new_twitter_id';
 
-      // 1. 初期データの準備
       when(mockAuthRepository.fetchCurrentUserAttributes())
           .thenAnswer((_) async => initialAttributes);
       
-      // 2. 更新処理のモック
-      when(mockAuthRepository.updateUserAttributes(username: newUsername, bio: newBio))
-          .thenAnswer((_) async {});
+      when(mockAuthRepository.updateUserAttributes(
+        username: newUsername,
+        bio: newBio,
+        twitterId: newTwitterId,
+      )).thenAnswer((_) async {});
       
-      // 3. ProfilePageを描画
       await tester.pumpWidget(createTestApp(const ProfilePage()));
       await tester.pumpAndSettle();
 
-      // 4. 編集画面へ遷移
       await tester.tap(find.byIcon(Icons.edit));
       await tester.pumpAndSettle();
 
-      // 5. テキストを入力
       await tester.enterText(find.widgetWithText(TextFormField, initialUsername), newUsername);
       await tester.enterText(find.widgetWithText(TextFormField, initialBio), newBio);
+      // --- ▼▼▼ ここから追加 ▼▼▼ ---
+      await tester.enterText(find.widgetWithText(TextFormField, initialTwitterId), newTwitterId); // Twitter IDの入力ステップを追加
+      // --- ▲▲▲ ここまで追加 ▲▲▲ ---
       
-      // 6. 保存ボタンをタップ
       await tester.tap(find.text('変更を保存'));
-      await tester.pumpAndSettle(); // 画面遷移と状態更新を待つ
+      await tester.pumpAndSettle();
 
-      // 7. ProfilePageに戻り、UIが更新されたことを確認
       expect(find.byType(ProfilePage), findsOneWidget);
       expect(find.byType(EditProfilePage), findsNothing);
-      expect(find.text(newUsername), findsOneWidget); // 更新後の名前が表示されている
-      expect(find.text(newBio), findsOneWidget);      // 更新後の自己紹介が表示されている
-      expect(find.text('変更に成功しました'), findsOneWidget); // SnackBarが表示される
+      expect(find.text(newUsername), findsOneWidget);
+      expect(find.text(newBio), findsOneWidget);
+      expect(find.text('@$newTwitterId'), findsOneWidget);
+      expect(find.text('変更に成功しました'), findsOneWidget);
     });
 
     testWidgets('[PROFILE-WIDGET-004] EditProfilePage - ユーザー名が空の場合にバリデーションエラーが表示される', (tester) async {
@@ -113,10 +120,9 @@ void main() {
       await tester.tap(find.byIcon(Icons.edit));
       await tester.pumpAndSettle();
 
-      // ユーザー名を空にする
       await tester.enterText(find.widgetWithText(TextFormField, initialUsername), '');
       await tester.tap(find.text('変更を保存'));
-      await tester.pump(); // バリデーションエラーの表示を待つ
+      await tester.pump();
 
       expect(find.text('ユーザー名を入力してください'), findsOneWidget);
     });

--- a/test/mocks.mocks.dart
+++ b/test/mocks.mocks.dart
@@ -74,27 +74,37 @@ class MockAuthRepository extends _i1.Mock implements _i3.AuthRepository {
     _i1.throwOnMissingStub(this);
   }
 
-  _i4.Future<_i2.SignUpResult> signUp({
-    required String? password,
+  @override
+  _i4.Future<_i2.SignUpResult> signUpWithProfile({
     required String? email,
+    required String? password,
+    required String? username,
+    String? bio,
+    String? twitterId,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
-          #signUp,
+          #signUpWithProfile,
           [],
           {
-            #password: password,
             #email: email,
+            #password: password,
+            #username: username,
+            #bio: bio,
+            #twitterId: twitterId,
           },
         ),
         returnValue: _i4.Future<_i2.SignUpResult>.value(_FakeSignUpResult_0(
           this,
           Invocation.method(
-            #signUp,
+            #signUpWithProfile,
             [],
             {
-              #password: password,
               #email: email,
+              #password: password,
+              #username: username,
+              #bio: bio,
+              #twitterId: twitterId,
             },
           ),
         )),
@@ -126,6 +136,18 @@ class MockAuthRepository extends _i1.Mock implements _i3.AuthRepository {
           ),
         )),
       ) as _i4.Future<_i2.SignUpResult>);
+
+  @override
+  _i4.Future<void> resendSignUpCode({required String? username}) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #resendSignUpCode,
+          [],
+          {#username: username},
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
 
   @override
   _i4.Future<_i2.SignInResult> signIn({

--- a/test/mocks.mocks.dart
+++ b/test/mocks.mocks.dart
@@ -25,25 +25,45 @@ import 'package:my_madamis_app/features/auth/data/auth_repository.dart' as _i3;
 // ignore_for_file: invalid_use_of_internal_member
 
 class _FakeSignUpResult_0 extends _i1.SmartFake implements _i2.SignUpResult {
-  _FakeSignUpResult_0(Object parent, Invocation parentInvocation)
-    : super(parent, parentInvocation);
+  _FakeSignUpResult_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeSignInResult_1 extends _i1.SmartFake implements _i2.SignInResult {
-  _FakeSignInResult_1(Object parent, Invocation parentInvocation)
-    : super(parent, parentInvocation);
+  _FakeSignInResult_1(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeResetPasswordResult_2 extends _i1.SmartFake
     implements _i2.ResetPasswordResult {
-  _FakeResetPasswordResult_2(Object parent, Invocation parentInvocation)
-    : super(parent, parentInvocation);
+  _FakeResetPasswordResult_2(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeResetPasswordStep_3 extends _i1.SmartFake
     implements _i2.ResetPasswordStep {
-  _FakeResetPasswordStep_3(Object parent, Invocation parentInvocation)
-    : super(parent, parentInvocation);
+  _FakeResetPasswordStep_3(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 /// A class which mocks [AuthRepository].
@@ -61,23 +81,28 @@ class MockAuthRepository extends _i1.Mock implements _i3.AuthRepository {
     required String? email,
   }) =>
       (super.noSuchMethod(
-            Invocation.method(#signUp, [], {
+        Invocation.method(
+          #signUp,
+          [],
+          {
+            #username: username,
+            #password: password,
+            #email: email,
+          },
+        ),
+        returnValue: _i4.Future<_i2.SignUpResult>.value(_FakeSignUpResult_0(
+          this,
+          Invocation.method(
+            #signUp,
+            [],
+            {
               #username: username,
               #password: password,
               #email: email,
-            }),
-            returnValue: _i4.Future<_i2.SignUpResult>.value(
-              _FakeSignUpResult_0(
-                this,
-                Invocation.method(#signUp, [], {
-                  #username: username,
-                  #password: password,
-                  #email: email,
-                }),
-              ),
-            ),
-          )
-          as _i4.Future<_i2.SignUpResult>);
+            },
+          ),
+        )),
+      ) as _i4.Future<_i2.SignUpResult>);
 
   @override
   _i4.Future<_i2.SignUpResult> confirmSignUp({
@@ -85,21 +110,26 @@ class MockAuthRepository extends _i1.Mock implements _i3.AuthRepository {
     required String? confirmationCode,
   }) =>
       (super.noSuchMethod(
-            Invocation.method(#confirmSignUp, [], {
+        Invocation.method(
+          #confirmSignUp,
+          [],
+          {
+            #username: username,
+            #confirmationCode: confirmationCode,
+          },
+        ),
+        returnValue: _i4.Future<_i2.SignUpResult>.value(_FakeSignUpResult_0(
+          this,
+          Invocation.method(
+            #confirmSignUp,
+            [],
+            {
               #username: username,
               #confirmationCode: confirmationCode,
-            }),
-            returnValue: _i4.Future<_i2.SignUpResult>.value(
-              _FakeSignUpResult_0(
-                this,
-                Invocation.method(#confirmSignUp, [], {
-                  #username: username,
-                  #confirmationCode: confirmationCode,
-                }),
-              ),
-            ),
-          )
-          as _i4.Future<_i2.SignUpResult>);
+            },
+          ),
+        )),
+      ) as _i4.Future<_i2.SignUpResult>);
 
   @override
   _i4.Future<_i2.SignInResult> signIn({
@@ -107,44 +137,54 @@ class MockAuthRepository extends _i1.Mock implements _i3.AuthRepository {
     required String? password,
   }) =>
       (super.noSuchMethod(
-            Invocation.method(#signIn, [], {
+        Invocation.method(
+          #signIn,
+          [],
+          {
+            #username: username,
+            #password: password,
+          },
+        ),
+        returnValue: _i4.Future<_i2.SignInResult>.value(_FakeSignInResult_1(
+          this,
+          Invocation.method(
+            #signIn,
+            [],
+            {
               #username: username,
               #password: password,
-            }),
-            returnValue: _i4.Future<_i2.SignInResult>.value(
-              _FakeSignInResult_1(
-                this,
-                Invocation.method(#signIn, [], {
-                  #username: username,
-                  #password: password,
-                }),
-              ),
-            ),
-          )
-          as _i4.Future<_i2.SignInResult>);
+            },
+          ),
+        )),
+      ) as _i4.Future<_i2.SignInResult>);
 
   @override
   _i4.Future<List<_i2.AuthUserAttribute>> fetchUserAttributes() =>
       (super.noSuchMethod(
-            Invocation.method(#fetchUserAttributes, []),
-            returnValue: _i4.Future<List<_i2.AuthUserAttribute>>.value(
-              <_i2.AuthUserAttribute>[],
-            ),
-          )
-          as _i4.Future<List<_i2.AuthUserAttribute>>);
+        Invocation.method(
+          #fetchUserAttributes,
+          [],
+        ),
+        returnValue: _i4.Future<List<_i2.AuthUserAttribute>>.value(
+            <_i2.AuthUserAttribute>[]),
+      ) as _i4.Future<List<_i2.AuthUserAttribute>>);
 
   @override
   _i4.Future<_i2.ResetPasswordResult> resetPassword(String? username) =>
       (super.noSuchMethod(
-            Invocation.method(#resetPassword, [username]),
-            returnValue: _i4.Future<_i2.ResetPasswordResult>.value(
-              _FakeResetPasswordResult_2(
-                this,
-                Invocation.method(#resetPassword, [username]),
-              ),
-            ),
-          )
-          as _i4.Future<_i2.ResetPasswordResult>);
+        Invocation.method(
+          #resetPassword,
+          [username],
+        ),
+        returnValue: _i4.Future<_i2.ResetPasswordResult>.value(
+            _FakeResetPasswordResult_2(
+          this,
+          Invocation.method(
+            #resetPassword,
+            [username],
+          ),
+        )),
+      ) as _i4.Future<_i2.ResetPasswordResult>);
 
   @override
   _i4.Future<void> confirmResetPassword({
@@ -153,51 +193,60 @@ class MockAuthRepository extends _i1.Mock implements _i3.AuthRepository {
     required String? confirmationCode,
   }) =>
       (super.noSuchMethod(
-            Invocation.method(#confirmResetPassword, [], {
-              #username: username,
-              #newPassword: newPassword,
-              #confirmationCode: confirmationCode,
-            }),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
-          )
-          as _i4.Future<void>);
+        Invocation.method(
+          #confirmResetPassword,
+          [],
+          {
+            #username: username,
+            #newPassword: newPassword,
+            #confirmationCode: confirmationCode,
+          },
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
 
   @override
-  _i4.Future<void> signOut() =>
-      (super.noSuchMethod(
-            Invocation.method(#signOut, []),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
-          )
-          as _i4.Future<void>);
+  _i4.Future<void> signOut() => (super.noSuchMethod(
+        Invocation.method(
+          #signOut,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
 
   @override
   _i4.Future<Map<_i2.AuthUserAttributeKey, String>>
-  fetchCurrentUserAttributes() =>
-      (super.noSuchMethod(
-            Invocation.method(#fetchCurrentUserAttributes, []),
+      fetchCurrentUserAttributes() => (super.noSuchMethod(
+            Invocation.method(
+              #fetchCurrentUserAttributes,
+              [],
+            ),
             returnValue:
                 _i4.Future<Map<_i2.AuthUserAttributeKey, String>>.value(
-                  <_i2.AuthUserAttributeKey, String>{},
-                ),
-          )
-          as _i4.Future<Map<_i2.AuthUserAttributeKey, String>>);
+                    <_i2.AuthUserAttributeKey, String>{}),
+          ) as _i4.Future<Map<_i2.AuthUserAttributeKey, String>>);
 
   @override
   _i4.Future<void> updateUserAttributes({
     required String? username,
     required String? bio,
+    required String? twitterId,
   }) =>
       (super.noSuchMethod(
-            Invocation.method(#updateUserAttributes, [], {
-              #username: username,
-              #bio: bio,
-            }),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
-          )
-          as _i4.Future<void>);
+        Invocation.method(
+          #updateUserAttributes,
+          [],
+          {
+            #username: username,
+            #bio: bio,
+            #twitterId: twitterId,
+          },
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
 }
 
 /// A class which mocks [ResetPasswordResult].
@@ -210,29 +259,26 @@ class MockResetPasswordResult extends _i1.Mock
   }
 
   @override
-  bool get isPasswordReset =>
-      (super.noSuchMethod(
-            Invocation.getter(#isPasswordReset),
-            returnValue: false,
-          )
-          as bool);
+  bool get isPasswordReset => (super.noSuchMethod(
+        Invocation.getter(#isPasswordReset),
+        returnValue: false,
+      ) as bool);
 
   @override
-  _i2.ResetPasswordStep get nextStep =>
-      (super.noSuchMethod(
-            Invocation.getter(#nextStep),
-            returnValue: _FakeResetPasswordStep_3(
-              this,
-              Invocation.getter(#nextStep),
-            ),
-          )
-          as _i2.ResetPasswordStep);
+  _i2.ResetPasswordStep get nextStep => (super.noSuchMethod(
+        Invocation.getter(#nextStep),
+        returnValue: _FakeResetPasswordStep_3(
+          this,
+          Invocation.getter(#nextStep),
+        ),
+      ) as _i2.ResetPasswordStep);
 
   @override
-  Map<String, Object?> toJson() =>
-      (super.noSuchMethod(
-            Invocation.method(#toJson, []),
-            returnValue: <String, Object?>{},
-          )
-          as Map<String, Object?>);
+  Map<String, Object?> toJson() => (super.noSuchMethod(
+        Invocation.method(
+          #toJson,
+          [],
+        ),
+        returnValue: <String, Object?>{},
+      ) as Map<String, Object?>);
 }

--- a/test/mocks.mocks.dart
+++ b/test/mocks.mocks.dart
@@ -74,7 +74,6 @@ class MockAuthRepository extends _i1.Mock implements _i3.AuthRepository {
     _i1.throwOnMissingStub(this);
   }
 
-  @override
   _i4.Future<_i2.SignUpResult> signUp({
     required String? password,
     required String? email,

--- a/test/mocks.mocks.dart
+++ b/test/mocks.mocks.dart
@@ -76,7 +76,6 @@ class MockAuthRepository extends _i1.Mock implements _i3.AuthRepository {
 
   @override
   _i4.Future<_i2.SignUpResult> signUp({
-    required String? username,
     required String? password,
     required String? email,
   }) =>
@@ -85,7 +84,6 @@ class MockAuthRepository extends _i1.Mock implements _i3.AuthRepository {
           #signUp,
           [],
           {
-            #username: username,
             #password: password,
             #email: email,
           },
@@ -96,7 +94,6 @@ class MockAuthRepository extends _i1.Mock implements _i3.AuthRepository {
             #signUp,
             [],
             {
-              #username: username,
               #password: password,
               #email: email,
             },
@@ -231,8 +228,8 @@ class MockAuthRepository extends _i1.Mock implements _i3.AuthRepository {
   @override
   _i4.Future<void> updateUserAttributes({
     required String? username,
-    required String? bio,
-    required String? twitterId,
+    String? bio,
+    String? twitterId,
   }) =>
       (super.noSuchMethod(
         Invocation.method(


### PR DESCRIPTION
**プロフィール作成機能/新規登録フローの改善と堅牢性の向上**

**概要**
　このマージリクエストは、ユーザーの新規登録（サインアップ）フローを全面的に改善しました。

　従来のフローでは、ユーザー名やパスワードを早期に登録していたため、**フローを途中で離脱したユーザーが再度登録できなくなる問題がありました。**
　本改修では、登録プロセスを**「メールアドレス入力」と「プロフィールとパスワードの設定」**の2段階に分離し、ユーザーが全ての必須情報を入力し終えた段階で初めてサインアップ処理を実行するように変更しました。

　加えて、ユーザーが遭遇しうる様々なエラーケースを想定し、それらを適切にハンドリングして登録完了までスムーズに誘導するロジックを実装しました。これらの変更を保証するため、ユーザーの操作をシミュレートする網羅的なウィジェットテストも追加。

**機能の変更点詳細**
　1. 新規登録フローの刷新
　　メールアドレスの先行登録 (SignUpPage):
　　新規登録の最初のステップとして、メールアドレスのみを入力する画面を新設しました。
　　ここで入力されたメールアドレスは、次のプロフィール作成画面に引き継がれます。
　　プロフィールとパスワードの一括登録 (CreateProfilePage):
　　ユーザー名（必須）、パスワード（必須）、自己紹介（任意）、X(Twitter) ID（任意）を入力する画面に機能を統合しました。
　　「利用を開始する」ボタンが押されたタイミングで、初めてAmplifyのsignUpAPIが呼び出され、ユーザーがCognitoに登録されます。

　2. 認証フローと状態管理の改善 (AuthStateNotifier)
　　認証完了後の自動サインイン:
　　ユーザーが確認コードの入力に成功した場合、即座にsignIn処理を内部的に実行します。
　　これにより、ユーザーは登録完了後に再度ログイン情報を入力することなく、シームレスにホーム画面へ遷移できます。
　　中断ユーザーへの対応ロジック:
　　UsernameExistsExceptionのハンドリング:
　　登録処理中に「ユーザーが既に存在する」エラーが返された場合、「ユーザーは存在するが未認証である」と判断します。
　　確認コードを自動で再送し、ユーザーをコード入力画面へ誘導することで、フローの中断後も登録を再開できるようにしました。
　　UserNotConfirmedExceptionのハンドリング:
　　未認証のユーザーがログインを試みた場合に発生するエラーを検知します。
　　この場合も同様に、確認コードを再送してコード入力画面へ誘導し、ユーザーがログインフローからも登録を完了できるようにしました。

　3. バックエンド連携の修正 (AuthRepository)
　　signUpWithProfileメソッドの新設:
　　画面で入力された全ての情報（メール、パスワード、プロフィール）を一度にCognitoへ送信するためのメソッドを実装しました。
　　resendSignUpCodeメソッドの追加:
　　上記のエラーハンドリングを実現するため、確認コードを再送するメソッドを追加しました。

テストの解説
新しい認証フローの品質を保証するため、test/features/auth/presentation/pages/signup_flow_test.dartに網羅的なウィジェットテストを追加しました。

このテストスイートは、ユーザーの実際の操作を想定し、正常系から異常系、中断からの復帰シナリオまでを幅広くカバーしています。

テストシナリオ一覧
[SIGNUP-FLOW-001] 正常系（全項目入力）:

ユーザーが全てのプロフィール項目（任意項目含む）を入力し、正常にサインアップが完了してホーム画面に遷移することを確認します。

[SIGNUP-FLOW-002] 正常系（任意項目なし）:

ユーザーが必須項目のみを入力し、任意項目を空のままサインアップを完了できることを確認します。

[SIGNUP-FLOW-003] 異常系（ユーザー登録済み）:

登録済みのメールアドレスで再度登録を試みた場合に、UsernameExistsExceptionを正しくハンドリングし、コード再送の案内と共に確認画面へ遷移することを検証します。

[SIGNUP-FLOW-004] 異常系（未認証ユーザーのログイン）:

未認証状態のユーザーがログインを試みた場合に、UserNotConfirmedExceptionを正しくハンドリングし、コード再送の案内と共に確認画面へ遷移することを検証します。

[SIGNUP-FLOW-005] 異常系（確認コード間違い）:

ユーザーが間違った確認コードを入力した場合に、エラーメッセージが適切に表示され、ホーム画面に遷移しないことを確認します。

これらのテストにより、新しい認証フローが様々な状況下で安定して動作し、高品質なユーザー体験を提供できることを保証します。

参考：[チャット](https://gemini.google.com/app/a29e92123c3dd9f3?is_sa=1&is_sa=1&android-min-version=301356232&ios-min-version=322.0&campaign_id=bkws&utm_source=sem&utm_source=google&utm_medium=paid-media&utm_medium=cpc&utm_campaign=bkws&utm_campaign=2024jaJP_gemfeb&pt=9008&mt=8&ct=p-growth-sem-bkws&gclsrc=aw.ds&gad_source=1&gad_campaignid=20437330680&gbraid=0AAAAApk5BhlZ5G0GYFye14fHisN_HfUqR&gclid=Cj0KCQjw0NPGBhCDARIsAGAzpp1ry-ymbbFbeuJwi3rwc2a1T1WJaind6E38Nf7hkWEOT5WN83a83GkaAnfNEALw_wcB)