### PR TITLE
Feat: 設定機能を追加し、認証フローのテストを修正

### DIFF
--- a/lib/features/auth/data/auth_repository.dart
+++ b/lib/features/auth/data/auth_repository.dart
@@ -168,4 +168,44 @@ class AuthRepository {
       rethrow;
     }
   }
+
+    /// ユーザーのメールアドレス属性を更新するためのリクエストを送信します。
+  Future<UpdateUserAttributeResult> updateEmail(String newEmail) async {
+    try {
+      final result = await Amplify.Auth.updateUserAttribute(
+        userAttributeKey: AuthUserAttributeKey.email,
+        value: newEmail,
+      );
+      return result;
+    } on AuthException {
+      rethrow;
+    }
+  }
+
+  /// メールアドレス更新用の確認コードを送信して、変更を確定します。
+  Future<void> confirmUpdateEmail(String confirmationCode) async {
+    try {
+      await Amplify.Auth.confirmUserAttribute(
+        userAttributeKey: AuthUserAttributeKey.email,
+        confirmationCode: confirmationCode,
+      );
+    } on AuthException {
+      rethrow;
+    }
+  }
+
+  /// サインイン中のユーザーのパスワードを変更します。
+  Future<void> updatePassword({
+    required String oldPassword,
+    required String newPassword,
+  }) async {
+    try {
+      await Amplify.Auth.updatePassword(
+        oldPassword: oldPassword,
+        newPassword: newPassword,
+      );
+    } on AuthException {
+      rethrow;
+    }
+  }
 }

--- a/lib/features/auth/presentation/notifiers/auth_state_notifier.dart
+++ b/lib/features/auth/presentation/notifiers/auth_state_notifier.dart
@@ -5,14 +5,17 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../data/auth_repository.dart';
 
 enum AuthStatus {
-  initial,
+ initial,
   loading,
   authenticated,
   unauthenticated,
   confirmationRequired,
+  confirmationRequiredForUpdate, // メール更新時のコード確認状態
   profileSetupRequired,
   passwordResetRequired,
   passwordResetSuccess,
+  emailUpdateSuccess, // メール更新成功状態
+  passwordUpdateSuccess, // パスワード更新成功状態
   error,
 }
 
@@ -34,10 +37,12 @@ class AuthState {
     String? errorMessage,
     String? usernameForConfirmation,
     String? username,
+    bool resetErrorMessage = false, // パラメータを追加
   }) {
     return AuthState(
       status: status ?? this.status,
-      errorMessage: errorMessage,
+      // resetErrorMessageがtrueならnullに、そうでなければ通常通り更新
+      errorMessage: resetErrorMessage ? null : errorMessage ?? this.errorMessage,
       usernameForConfirmation:
           usernameForConfirmation ?? this.usernameForConfirmation,
       username: username ?? this.username,
@@ -51,6 +56,7 @@ final authStateNotifierProvider =
 });
 
 class AuthStateNotifier extends StateNotifier<AuthState> {
+  //新しいメソッドを追加したときは"flutter pub run build_runner build --delete-conflicting-outputs"を入力。 
   final AuthRepository _authRepository;
 
   AuthStateNotifier(this._authRepository)
@@ -194,6 +200,62 @@ class AuthStateNotifier extends StateNotifier<AuthState> {
   Future<void> signOut() async {
     await _authRepository.signOut();
     state = const AuthState(status: AuthStatus.unauthenticated);
+  }
+
+    Future<void> updateEmail(String newEmail) async {
+    state = state.copyWith(status: AuthStatus.loading, resetErrorMessage: true);
+    try {
+      await _authRepository.updateEmail(newEmail);
+      state = state.copyWith(
+        status: AuthStatus.confirmationRequiredForUpdate,
+        usernameForConfirmation: newEmail,
+      );
+    } on AuthException catch (e) {
+      state = state.copyWith(
+        status: AuthStatus.error,
+        errorMessage: 'メールアドレスの変更リクエストに失敗しました: ${e.message}',
+      );
+    }
+  }
+
+  Future<void> confirmUpdateEmail(String confirmationCode) async {
+    state = state.copyWith(status: AuthStatus.loading, resetErrorMessage: true);
+    try {
+      await _authRepository.confirmUpdateEmail(confirmationCode);
+      state = state.copyWith(status: AuthStatus.emailUpdateSuccess);
+    } on AuthException catch (e) {
+      state = state.copyWith(
+        status: AuthStatus.error,
+        errorMessage: 'メールアドレスの変更に失敗しました: ${e.message}',
+      );
+    }
+  }
+
+  Future<void> updatePassword({
+    required String oldPassword,
+    required String newPassword,
+  }) async {
+    state = state.copyWith(status: AuthStatus.loading, resetErrorMessage: true);
+    try {
+      await _authRepository.updatePassword(
+        oldPassword: oldPassword,
+        newPassword: newPassword,
+      );
+      state = state.copyWith(status: AuthStatus.passwordUpdateSuccess);
+    } on AuthException catch (e) {
+      state = state.copyWith(
+        status: AuthStatus.error,
+        errorMessage: 'パスワードの変更に失敗しました: ${e.message}',
+      );
+    }
+  }
+
+  /// 画面遷移後などに、一時的な状態をリセットする
+  void resetStatus() {
+    state = state.copyWith(
+      status: AuthStatus.initial,
+      resetErrorMessage: true,
+    );
   }
 
   /// プロフィール更新時にユーザー名を同期するためのメソッド

--- a/lib/features/auth/presentation/notifiers/auth_state_notifier.dart
+++ b/lib/features/auth/presentation/notifiers/auth_state_notifier.dart
@@ -215,7 +215,12 @@ class AuthStateNotifier extends StateNotifier<AuthState> {
         status: AuthStatus.error,
         errorMessage: 'メールアドレスの変更リクエストに失敗しました: ${e.message}',
       );
-    }
+    }catch (e) { 
+      state = state.copyWith(
+        status: AuthStatus.error,
+        errorMessage: '予期せぬエラーが発生しました: $e',
+      );
+    } 
   }
 
   Future<void> confirmUpdateEmail(String confirmationCode) async {
@@ -227,6 +232,11 @@ class AuthStateNotifier extends StateNotifier<AuthState> {
       state = state.copyWith(
         status: AuthStatus.error,
         errorMessage: 'メールアドレスの変更に失敗しました: ${e.message}',
+      );
+    } catch (e) {
+      state = state.copyWith(
+        status: AuthStatus.error,
+        errorMessage: '予期せぬエラーが発生しました: $e',
       );
     }
   }
@@ -246,6 +256,11 @@ class AuthStateNotifier extends StateNotifier<AuthState> {
       state = state.copyWith(
         status: AuthStatus.error,
         errorMessage: 'パスワードの変更に失敗しました: ${e.message}',
+      );
+    } catch (e) { 
+      state = state.copyWith(
+        status: AuthStatus.error,
+        errorMessage: '予期せぬエラーが発生しました: $e',
       );
     }
   }

--- a/lib/features/home/presentation/pages/home_page.dart
+++ b/lib/features/home/presentation/pages/home_page.dart
@@ -1,12 +1,12 @@
-// ファイルパス: lib/features/home/presentation/pages/home_page.dart
+// lib/features/home/presentation/pages/home_page.dart
 
 import 'package:flutter/material.dart';
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-// ▼▼▼ 1. import文を追加 ▼▼▼
 import 'package:my_madamis_app/features/profile/presentation/pages/profile_page.dart';
+
 import '../../../auth/presentation/notifiers/auth_state_notifier.dart';
 import '../../../auth/presentation/pages/login_page.dart';
+import '../../../settings/presentation/pages/settings_page.dart';
 
 class HomePage extends ConsumerWidget {
   const HomePage({super.key});
@@ -27,10 +27,9 @@ class HomePage extends ConsumerWidget {
       appBar: AppBar(
         title: const Text('ホーム'),
         actions: [
-          // --- ▼▼▼ 2. IconButtonを追加 ▼▼▼ ---
           IconButton(
             icon: const Icon(Icons.person_outline),
-            tooltip: 'プロフィール', // アイコン長押しで表示されるテキスト
+            tooltip: 'プロフィール',
             onPressed: () {
               Navigator.push(
                 context,
@@ -38,8 +37,18 @@ class HomePage extends ConsumerWidget {
               );
             },
           ),
-          // --- ▲▲▲ IconButtonの追加ここまで ▲▲▲ ---
-          // サインアウトボタン
+          // --- ▼▼▼ 歯車アイコンを追加 ▼▼▼ ---
+          IconButton(
+            icon: const Icon(Icons.settings),
+            tooltip: '設定',
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const SettingsPage()),
+              );
+            },
+          ),
+          // --- ▲▲▲ ここまで追加 ▲▲▲ ---
           IconButton(
             icon: const Icon(Icons.logout),
             tooltip: 'サインアウト',

--- a/lib/features/settings/presentation/pages/confirm_update_email_page.dart
+++ b/lib/features/settings/presentation/pages/confirm_update_email_page.dart
@@ -1,0 +1,87 @@
+// lib/features/settings/presentation/pages/confirm_update_email_page.dart
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:my_madamis_app/features/auth/presentation/notifiers/auth_state_notifier.dart';
+
+class ConfirmUpdateEmailPage extends ConsumerStatefulWidget {
+  final String newEmail;
+  const ConfirmUpdateEmailPage({super.key, required this.newEmail});
+
+  @override
+  ConsumerState<ConfirmUpdateEmailPage> createState() =>
+      _ConfirmUpdateEmailPageState();
+}
+
+class _ConfirmUpdateEmailPageState
+    extends ConsumerState<ConfirmUpdateEmailPage> {
+  final _codeController = TextEditingController();
+
+  @override
+  void dispose() {
+    _codeController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    ref.listen(authStateNotifierProvider, (_, next) {
+      if (next.status == AuthStatus.emailUpdateSuccess) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('メールアドレスが正常に変更されました。'),
+            behavior: SnackBarBehavior.floating,
+            backgroundColor: Colors.green,
+          ),
+        );
+        // 設定画面まで戻る (2画面分)
+        Navigator.of(context).pop();
+        Navigator.of(context).pop();
+      } else if (next.status == AuthStatus.error) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('エラー: ${next.errorMessage}'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    });
+
+    final authState = ref.watch(authStateNotifierProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('確認コード入力')),
+      body: Padding(
+        padding: const EdgeInsets.all(20.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text('${widget.newEmail} に送信された確認コードを入力してください。'),
+            const SizedBox(height: 16),
+            TextFormField(
+              controller: _codeController,
+              decoration: const InputDecoration(
+                  labelText: '確認コード', border: OutlineInputBorder()),
+              keyboardType: TextInputType.number,
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: authState.status == AuthStatus.loading
+                  ? null
+                  : () => ref
+                      .read(authStateNotifierProvider.notifier)
+                      .confirmUpdateEmail(_codeController.text),
+              child: authState.status == AuthStatus.loading
+                  ? const SizedBox(
+                      height: 20,
+                      width: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2.5),
+                    )
+                  : const Text('変更を確定'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/settings/presentation/pages/settings_page.dart
+++ b/lib/features/settings/presentation/pages/settings_page.dart
@@ -1,0 +1,45 @@
+// lib/features/settings/presentation/pages/settings_page.dart
+
+import 'package:flutter/material.dart';
+import 'package:my_madamis_app/features/settings/presentation/pages/update_email_page.dart';
+import 'package:my_madamis_app/features/settings/presentation/pages/update_password_page.dart';
+
+class SettingsPage extends StatelessWidget {
+  const SettingsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('設定'),
+      ),
+      body: ListView(
+        children: [
+          ListTile(
+            leading: const Icon(Icons.email_outlined),
+            title: const Text('メールアドレス変更'),
+            subtitle: const Text('サインインに使用するメールアドレスを変更します'),
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const UpdateEmailPage()),
+              );
+            },
+          ),
+          const Divider(height: 1),
+          ListTile(
+            leading: const Icon(Icons.lock_outline),
+            title: const Text('パスワード変更'),
+            subtitle: const Text('サインインに使用するパスワードを変更します'),
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const UpdatePasswordPage()),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/settings/presentation/pages/update_email_page.dart
+++ b/lib/features/settings/presentation/pages/update_email_page.dart
@@ -1,0 +1,98 @@
+// lib/features/settings/presentation/pages/update_email_page.dart
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:my_madamis_app/features/auth/presentation/notifiers/auth_state_notifier.dart';
+import 'package:my_madamis_app/features/settings/presentation/pages/confirm_update_email_page.dart';
+
+class UpdateEmailPage extends ConsumerStatefulWidget {
+  const UpdateEmailPage({super.key});
+
+  @override
+  ConsumerState<UpdateEmailPage> createState() => _UpdateEmailPageState();
+}
+
+class _UpdateEmailPageState extends ConsumerState<UpdateEmailPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _emailController = TextEditingController();
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    if (_formKey.currentState!.validate()) {
+      ref
+          .read(authStateNotifierProvider.notifier)
+          .updateEmail(_emailController.text);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    ref.listen(authStateNotifierProvider, (_, next) {
+      if (next.status == AuthStatus.confirmationRequiredForUpdate) {
+        // 状態がリセットされるように、notifierの状態を一度リセット
+        ref.read(authStateNotifierProvider.notifier).resetStatus();
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (_) =>
+                ConfirmUpdateEmailPage(newEmail: _emailController.text),
+          ),
+        );
+      } else if (next.status == AuthStatus.error) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+              content: Text('エラー: ${next.errorMessage}'),
+              backgroundColor: Colors.red),
+        );
+      }
+    });
+
+    final authState = ref.watch(authStateNotifierProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('メールアドレス変更')),
+      body: Padding(
+        padding: const EdgeInsets.all(20.0),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              TextFormField(
+                controller: _emailController,
+                decoration: const InputDecoration(
+                    labelText: '新しいメールアドレス', border: OutlineInputBorder()),
+                keyboardType: TextInputType.emailAddress,
+                validator: (value) {
+                  if (value == null ||
+                      value.trim().isEmpty ||
+                      !value.contains('@')) {
+                    return '有効なメールアドレスを入力してください';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 24),
+              ElevatedButton(
+                onPressed: authState.status == AuthStatus.loading ? null : _submit,
+                child: authState.status == AuthStatus.loading
+                    ? const SizedBox(
+                        height: 20,
+                        width: 20,
+                        child:
+                            CircularProgressIndicator(strokeWidth: 2.5),
+                      )
+                    : const Text('確認コードを送信'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/settings/presentation/pages/update_password_page.dart
+++ b/lib/features/settings/presentation/pages/update_password_page.dart
@@ -1,0 +1,111 @@
+// lib/features/settings/presentation/pages/update_password_page.dart
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:my_madamis_app/features/auth/presentation/notifiers/auth_state_notifier.dart';
+
+class UpdatePasswordPage extends ConsumerStatefulWidget {
+  const UpdatePasswordPage({super.key});
+
+  @override
+  ConsumerState<UpdatePasswordPage> createState() => _UpdatePasswordPageState();
+}
+
+class _UpdatePasswordPageState extends ConsumerState<UpdatePasswordPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _oldPasswordController = TextEditingController();
+  final _newPasswordController = TextEditingController();
+
+  @override
+  void dispose() {
+    _oldPasswordController.dispose();
+    _newPasswordController.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    if (_formKey.currentState!.validate()) {
+      ref.read(authStateNotifierProvider.notifier).updatePassword(
+            oldPassword: _oldPasswordController.text,
+            newPassword: _newPasswordController.text,
+          );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    ref.listen(authStateNotifierProvider, (_, next) {
+      if (next.status == AuthStatus.passwordUpdateSuccess) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('パスワードが正常に変更されました。'),
+            behavior: SnackBarBehavior.floating,
+            backgroundColor: Colors.green,
+          ),
+        );
+        Navigator.of(context).pop();
+      } else if (next.status == AuthStatus.error) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('エラー: ${next.errorMessage}'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    });
+
+    final authState = ref.watch(authStateNotifierProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('パスワード変更')),
+      body: Padding(
+        padding: const EdgeInsets.all(20.0),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              TextFormField(
+                controller: _oldPasswordController,
+                obscureText: true,
+                decoration: const InputDecoration(
+                    labelText: '現在のパスワード', border: OutlineInputBorder()),
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return '現在のパスワードを入力してください';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _newPasswordController,
+                obscureText: true,
+                decoration: const InputDecoration(
+                    labelText: '新しいパスワード (8文字以上)',
+                    border: OutlineInputBorder()),
+                validator: (value) {
+                  if (value == null || value.length < 8) {
+                    return 'パスワードは8文字以上で入力してください';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 24),
+              ElevatedButton(
+                onPressed: authState.status == AuthStatus.loading ? null : _submit,
+                child: authState.status == AuthStatus.loading
+                    ? const SizedBox(
+                        height: 20,
+                        width: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2.5),
+                      )
+                    : const Text('パスワードを変更'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/features/auth/presentation/notifiers/auth_state_notifier_test.dart
+++ b/test/features/auth/presentation/notifiers/auth_state_notifier_test.dart
@@ -163,4 +163,147 @@ void main() {
       );
     });
   });
+ group('Email Update', () {
+      const newEmail = 'new@example.com';
+      const confirmationCode = '123456';
+
+      test('[NOTIFIER-006] updateEmail - 成功時にconfirmationRequiredForUpdate状態になる',
+          () async {
+        when(mockAuthRepository.updateEmail(newEmail)).thenAnswer((_) async =>
+            const UpdateUserAttributeResult(
+                isUpdated: false,
+                nextStep: AuthNextUpdateAttributeStep(
+                    updateAttributeStep:
+                        AuthUpdateAttributeStep.confirmAttributeWithCode)));
+
+        final notifier = container.read(authStateNotifierProvider.notifier);
+
+        expect(
+          notifier.stream,
+          emitsInOrder([
+            isA<AuthState>()
+                .having((s) => s.status, 'status', AuthStatus.loading),
+            isA<AuthState>()
+                .having((s) => s.status, 'status',
+                    AuthStatus.confirmationRequiredForUpdate)
+                .having((s) => s.usernameForConfirmation,
+                    'usernameForConfirmation', newEmail),
+          ]),
+        );
+
+        await notifier.updateEmail(newEmail);
+      });
+
+      test('[NOTIFIER-007] updateEmail - 失敗時にerror状態になる', () async {
+        final exception = Exception('Update failed');
+        when(mockAuthRepository.updateEmail(newEmail)).thenThrow(exception);
+
+        final notifier = container.read(authStateNotifierProvider.notifier);
+
+        expect(
+          notifier.stream,
+          emitsInOrder([
+            isA<AuthState>()
+                .having((s) => s.status, 'status', AuthStatus.loading),
+            isA<AuthState>()
+                .having((s) => s.status, 'status', AuthStatus.error)
+                .having((s) => s.errorMessage, 'errorMessage', isNotNull),
+          ]),
+        );
+
+        await notifier.updateEmail(newEmail);
+      });
+
+      test('[NOTIFIER-008] confirmUpdateEmail - 成功時にemailUpdateSuccess状態になる',
+          () async {
+        when(mockAuthRepository.confirmUpdateEmail(confirmationCode))
+            .thenAnswer((_) async {});
+
+        final notifier = container.read(authStateNotifierProvider.notifier);
+
+        expect(
+          notifier.stream,
+          emitsInOrder([
+            isA<AuthState>()
+                .having((s) => s.status, 'status', AuthStatus.loading),
+            isA<AuthState>().having(
+                (s) => s.status, 'status', AuthStatus.emailUpdateSuccess),
+          ]),
+        );
+
+        await notifier.confirmUpdateEmail(confirmationCode);
+      });
+
+      test('[NOTIFIER-009] confirmUpdateEmail - 失敗時にerror状態になる', () async {
+        final exception = Exception('Confirmation failed');
+        when(mockAuthRepository.confirmUpdateEmail(confirmationCode))
+            .thenThrow(exception);
+
+        final notifier = container.read(authStateNotifierProvider.notifier);
+
+        expect(
+          notifier.stream,
+          emitsInOrder([
+            isA<AuthState>()
+                .having((s) => s.status, 'status', AuthStatus.loading),
+            isA<AuthState>()
+                .having((s) => s.status, 'status', AuthStatus.error)
+                .having((s) => s.errorMessage, 'errorMessage', isNotNull),
+          ]),
+        );
+
+        await notifier.confirmUpdateEmail(confirmationCode);
+      });
+    });
+
+    group('Password Update', () {
+      const oldPassword = 'oldPassword123';
+      const newPassword = 'newPassword123';
+
+      test('[NOTIFIER-010] updatePassword - 成功時にpasswordUpdateSuccess状態になる',
+          () async {
+        when(mockAuthRepository.updatePassword(
+                oldPassword: oldPassword, newPassword: newPassword))
+            .thenAnswer((_) async {});
+
+        final notifier = container.read(authStateNotifierProvider.notifier);
+
+        expect(
+          notifier.stream,
+          emitsInOrder([
+            isA<AuthState>()
+                .having((s) => s.status, 'status', AuthStatus.loading),
+            isA<AuthState>().having(
+                (s) => s.status, 'status', AuthStatus.passwordUpdateSuccess),
+          ]),
+        );
+
+        await notifier.updatePassword(
+            oldPassword: oldPassword, newPassword: newPassword);
+      });
+
+      test('[NOTIFIER-011] updatePassword - 失敗時にerror状態になる', () async {
+        final exception = Exception('Update failed');
+        when(mockAuthRepository.updatePassword(
+                oldPassword: oldPassword, newPassword: newPassword))
+            .thenThrow(exception);
+
+        final notifier = container.read(authStateNotifierProvider.notifier);
+
+        expect(
+          notifier.stream,
+          emitsInOrder([
+            isA<AuthState>()
+                .having((s) => s.status, 'status', AuthStatus.loading),
+            isA<AuthState>()
+                .having((s) => s.status, 'status', AuthStatus.error)
+                .having((s) => s.errorMessage, 'errorMessage', isNotNull),
+          ]),
+        );
+
+        await notifier.updatePassword(
+            oldPassword: oldPassword, newPassword: newPassword);
+      });
+    });
+
 }

--- a/test/features/settings/presentation/pages/settings_flow_test.dart
+++ b/test/features/settings/presentation/pages/settings_flow_test.dart
@@ -207,10 +207,14 @@ void main() {
 
       testWidgets('[SETTINGS-FLOW-006] 新しいパスワードがポリシー違反の場合にエラーが表示される',
           (tester) async {
+        // 1. バリデーションを通過するが、ポリシー違反とみなすパスワードを定義
+        const invalidPolicyPassword = 'invalid-password';
+
         // --- モックの設定 ---
+        // 2. モックが新しいパスワード('invalid-policy-password')を受け取った場合に例外を投げるように変更
         when(mockAuthRepository.updatePassword(
-                oldPassword: oldPassword, newPassword: 'short'))
-            .thenThrow(const InvalidPasswordException('Password is too short'));
+                oldPassword: oldPassword, newPassword: invalidPolicyPassword))
+            .thenThrow(const InvalidPasswordException('Password does not conform to policy'));
 
         // --- テスト実行 ---
         await tester.pumpWidget(createTestApp(home: const SettingsPage()));
@@ -218,17 +222,21 @@ void main() {
         await tester.tap(find.text('パスワード変更'));
         await tester.pumpAndSettle();
 
-        // バリデーション自体は通るがAPIでエラーになるケースを想定
+        // 3. バリデーション自体は通るがAPIでエラーになるケースを想定
         await tester.enterText(
             find.widgetWithText(TextFormField, '現在のパスワード'), oldPassword);
+        // 4. 新しいパスワードを入力
         await tester.enterText(
-            find.widgetWithText(TextFormField, '新しいパスワード (8文字以上)'), 'short');
+            find.widgetWithText(TextFormField, '新しいパスワード (8文字以上)'),
+            invalidPolicyPassword);
         await tester.tap(find.text('パスワードを変更'));
         await tester.pumpAndSettle();
 
         // --- 検証 ---
         expect(find.byType(UpdatePasswordPage), findsOneWidget);
+        // "エラー: パスワードの変更に失敗しました..." というSnackBarが表示されることを確認
         expect(find.textContaining('パスワードの変更に失敗しました'), findsOneWidget);
+
       });
 
         testWidgets('[SETTINGS-FLOW-007] パスワード入力フォームのクライアントサイドバリデーションが機能する',

--- a/test/features/settings/presentation/pages/settings_flow_test.dart
+++ b/test/features/settings/presentation/pages/settings_flow_test.dart
@@ -1,0 +1,258 @@
+// ファイルパス: test/features/settings/presentation/pages/settings_flow_test.dart
+
+import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:my_madamis_app/features/auth/data/auth_repository.dart';
+import 'package:my_madamis_app/features/home/presentation/pages/home_page.dart';
+import 'package:my_madamis_app/features/settings/presentation/pages/confirm_update_email_page.dart';
+import 'package:my_madamis_app/features/settings/presentation/pages/settings_page.dart';
+import 'package:my_madamis_app/features/settings/presentation/pages/update_email_page.dart';
+import 'package:my_madamis_app/features/settings/presentation/pages/update_password_page.dart';
+import 'package:my_madamis_app/main.dart' as app;
+
+import '../../../../mocks.mocks.dart';
+
+void main() {
+  late MockAuthRepository mockAuthRepository;
+
+  // テストウィジェットをラップするヘルパー
+  Widget createTestApp({required Widget home}) {
+    return ProviderScope(
+      overrides: [
+        authRepositoryProvider.overrideWithValue(mockAuthRepository),
+      ],
+      // MaterialAppでラップすることで、実際のアプリに近い環境でテストを実行
+      child: app.MyApp(home: home),
+    );
+  }
+
+  setUp(() {
+    mockAuthRepository = MockAuthRepository();
+    // ログイン済みの状態をモック
+    when(mockAuthRepository.fetchUserAttributes()).thenAnswer((_) async => [
+          const AuthUserAttribute(
+              userAttributeKey: AuthUserAttributeKey.preferredUsername,
+              value: 'test_user')
+        ]);
+  });
+
+  group('設定フロー ウィジェットテスト', () {
+    testWidgets('[SETTINGS-FLOW-001] ホーム画面から設定画面への遷移', (tester) async {
+      await tester.pumpWidget(createTestApp(home: const HomePage()));
+      await tester.pumpAndSettle();
+
+      // 歯車アイコンをタップ
+      await tester.tap(find.byIcon(Icons.settings));
+      await tester.pumpAndSettle();
+
+      // 設定画面が表示されていることを確認
+      expect(find.byType(SettingsPage), findsOneWidget);
+      expect(find.text('メールアドレス変更'), findsOneWidget);
+      expect(find.text('パスワード変更'), findsOneWidget);
+    });
+
+    group('メールアドレス変更フロー', () {
+      const newEmail = 'new.user@example.com';
+      const confirmationCode = '123456';
+
+      testWidgets('[SETTINGS-FLOW-002] 正常なメールアドレス変更フロー', (tester) async {
+        // --- モックの設定 ---
+        when(mockAuthRepository.updateEmail(any)).thenAnswer((_) async =>
+            const UpdateUserAttributeResult(
+                isUpdated: false,
+                nextStep: AuthNextUpdateAttributeStep(
+                    updateAttributeStep:
+                        AuthUpdateAttributeStep.confirmAttributeWithCode)));
+
+        when(mockAuthRepository.confirmUpdateEmail(any))
+            .thenAnswer((_) async {});
+
+        // --- テスト実行 ---
+        await tester.pumpWidget(createTestApp(home: const HomePage()));
+        await tester.pumpAndSettle();
+
+        // 1. 設定画面に遷移
+        await tester.tap(find.byIcon(Icons.settings));
+        await tester.pumpAndSettle();
+        expect(find.byType(SettingsPage), findsOneWidget);
+
+        // 2. メールアドレス変更画面に遷移
+        await tester.tap(find.text('メールアドレス変更'));
+        await tester.pumpAndSettle();
+        expect(find.byType(UpdateEmailPage), findsOneWidget);
+
+        // 3. 新しいメールアドレスを入力してコードを送信
+        await tester.enterText(
+            find.widgetWithText(TextFormField, '新しいメールアドレス'), newEmail);
+        await tester.tap(find.text('確認コードを送信'));
+        await tester.pumpAndSettle(); // 画面遷移を待つ
+
+        // 4. 確認画面に遷移したことを確認
+        expect(find.byType(ConfirmUpdateEmailPage), findsOneWidget);
+        expect(find.textContaining(newEmail), findsOneWidget);
+
+        // 5. 確認コードを入力して変更を確定
+        await tester.enterText(
+            find.widgetWithText(TextFormField, '確認コード'), confirmationCode);
+        await tester.tap(find.text('変更を確定'));
+        await tester.pumpAndSettle(); // 状態更新と画面遷移を待つ
+
+        // --- 検証 ---
+        // 6. 設定画面に戻り、成功のSnackBarが表示されることを確認
+        expect(find.byType(SettingsPage), findsOneWidget);
+        expect(find.text('メールアドレスが正常に変更されました。'), findsOneWidget);
+      });
+
+      testWidgets('[SETTINGS-FLOW-003] 確認コードが間違っている場合にエラーが表示される',
+          (tester) async {
+        // --- モックの設定 ---
+        when(mockAuthRepository.updateEmail(any)).thenAnswer((_) async =>
+            const UpdateUserAttributeResult(
+                isUpdated: false,
+                nextStep: AuthNextUpdateAttributeStep(
+                    updateAttributeStep:
+                        AuthUpdateAttributeStep.confirmAttributeWithCode)));
+
+        // コード不一致例外をスローするように設定
+        when(mockAuthRepository.confirmUpdateEmail(any))
+            .thenThrow(const CodeMismatchException('Invalid code'));
+
+        // --- テスト実行 ---
+        await tester.pumpWidget(createTestApp(home: const SettingsPage()));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('メールアドレス変更'));
+        await tester.pumpAndSettle();
+        await tester.enterText(
+            find.widgetWithText(TextFormField, '新しいメールアドレス'), newEmail);
+        await tester.tap(find.text('確認コードを送信'));
+        await tester.pumpAndSettle();
+        await tester.enterText(
+            find.widgetWithText(TextFormField, '確認コード'), 'wrong-code');
+        await tester.tap(find.text('変更を確定'));
+        await tester.pumpAndSettle();
+
+        // --- 検証 ---
+        // 確認画面に留まり、エラーメッセージが表示されることを確認
+        expect(find.byType(ConfirmUpdateEmailPage), findsOneWidget);
+        expect(find.textContaining('メールアドレスの変更に失敗しました'), findsOneWidget);
+      });
+    });
+
+    group('パスワード変更フロー', () {
+      const oldPassword = 'oldPassword123';
+      const newPassword = 'newPassword123';
+
+      testWidgets('[SETTINGS-FLOW-004] 正常なパスワード変更フロー', (tester) async {
+        // --- モックの設定 ---
+        when(mockAuthRepository.updatePassword(
+                oldPassword: oldPassword, newPassword: newPassword))
+            .thenAnswer((_) async {});
+
+        // --- テスト実行 ---
+        await tester.pumpWidget(createTestApp(home: const HomePage()));
+        await tester.pumpAndSettle();
+
+        // 1. 設定画面 > パスワード変更画面へ
+        await tester.tap(find.byIcon(Icons.settings));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('パスワード変更'));
+        await tester.pumpAndSettle();
+        expect(find.byType(UpdatePasswordPage), findsOneWidget);
+
+        // 2. パスワードを入力して変更ボタンをタップ
+        await tester.enterText(
+            find.widgetWithText(TextFormField, '現在のパスワード'), oldPassword);
+        await tester.enterText(
+            find.widgetWithText(TextFormField, '新しいパスワード (8文字以上)'),
+            newPassword);
+        await tester.tap(find.text('パスワードを変更'));
+        await tester.pumpAndSettle();
+
+        // --- 検証 ---
+        // 3. 設定画面に戻り、成功のSnackBarが表示されることを確認
+        expect(find.byType(SettingsPage), findsOneWidget);
+        expect(find.text('パスワードが正常に変更されました。'), findsOneWidget);
+      });
+
+      testWidgets('[SETTINGS-FLOW-005] 古いパスワードが間違っている場合にエラーが表示される',
+          (tester) async {
+        // --- モックの設定 ---
+        when(mockAuthRepository.updatePassword(
+                oldPassword: 'wrong-old-password', newPassword: newPassword))
+            .thenThrow(const NotAuthorizedServiceException('Incorrect password'));
+
+        // --- テスト実行 ---
+        await tester.pumpWidget(createTestApp(home: const SettingsPage()));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('パスワード変更'));
+        await tester.pumpAndSettle();
+
+        await tester.enterText(
+            find.widgetWithText(TextFormField, '現在のパスワード'),
+            'wrong-old-password');
+        await tester.enterText(
+            find.widgetWithText(TextFormField, '新しいパスワード (8文字以上)'),
+            newPassword);
+        await tester.tap(find.text('パスワードを変更'));
+        await tester.pumpAndSettle();
+
+        // --- 検証 ---
+        // パスワード変更画面に留まり、エラーメッセージが表示されることを確認
+        expect(find.byType(UpdatePasswordPage), findsOneWidget);
+        expect(find.textContaining('パスワードの変更に失敗しました'), findsOneWidget);
+      });
+
+      testWidgets('[SETTINGS-FLOW-006] 新しいパスワードがポリシー違反の場合にエラーが表示される',
+          (tester) async {
+        // --- モックの設定 ---
+        when(mockAuthRepository.updatePassword(
+                oldPassword: oldPassword, newPassword: 'short'))
+            .thenThrow(const InvalidPasswordException('Password is too short'));
+
+        // --- テスト実行 ---
+        await tester.pumpWidget(createTestApp(home: const SettingsPage()));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('パスワード変更'));
+        await tester.pumpAndSettle();
+
+        // バリデーション自体は通るがAPIでエラーになるケースを想定
+        await tester.enterText(
+            find.widgetWithText(TextFormField, '現在のパスワード'), oldPassword);
+        await tester.enterText(
+            find.widgetWithText(TextFormField, '新しいパスワード (8文字以上)'), 'short');
+        await tester.tap(find.text('パスワードを変更'));
+        await tester.pumpAndSettle();
+
+        // --- 検証 ---
+        expect(find.byType(UpdatePasswordPage), findsOneWidget);
+        expect(find.textContaining('パスワードの変更に失敗しました'), findsOneWidget);
+      });
+
+        testWidgets('[SETTINGS-FLOW-007] パスワード入力フォームのクライアントサイドバリデーションが機能する',
+          (tester) async {
+
+        await tester.pumpWidget(createTestApp(home: const UpdatePasswordPage()));
+        await tester.pumpAndSettle();
+
+        // 何も入力せずにボタンをタップ
+        await tester.tap(find.text('パスワードを変更'));
+        await tester.pump(); // 1フレーム進めてバリデーションエラーの表示を待つ
+
+        // エラーメッセージが表示されることを確認
+        expect(find.text('現在のパスワードを入力してください'), findsOneWidget);
+        expect(find.text('パスワードは8文字以上で入力してください'), findsOneWidget);
+
+        // 短いパスワードを入力
+        await tester.enterText(find.widgetWithText(TextFormField, '新しいパスワード (8文字以上)'), '123');
+        await tester.tap(find.text('パスワードを変更'));
+        await tester.pump();
+
+        // エラーメッセージが依然として表示されていることを確認
+        expect(find.text('パスワードは8文字以上で入力してください'), findsOneWidget);
+      });
+    });
+  });
+}

--- a/test/mocks.mocks.dart
+++ b/test/mocks.mocks.dart
@@ -55,9 +55,20 @@ class _FakeResetPasswordResult_2 extends _i1.SmartFake
         );
 }
 
-class _FakeResetPasswordStep_3 extends _i1.SmartFake
+class _FakeUpdateUserAttributeResult_3 extends _i1.SmartFake
+    implements _i2.UpdateUserAttributeResult {
+  _FakeUpdateUserAttributeResult_3(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeResetPasswordStep_4 extends _i1.SmartFake
     implements _i2.ResetPasswordStep {
-  _FakeResetPasswordStep_3(
+  _FakeResetPasswordStep_4(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -265,6 +276,52 @@ class MockAuthRepository extends _i1.Mock implements _i3.AuthRepository {
         returnValue: _i4.Future<void>.value(),
         returnValueForMissingStub: _i4.Future<void>.value(),
       ) as _i4.Future<void>);
+
+  @override
+  _i4.Future<_i2.UpdateUserAttributeResult> updateEmail(String? newEmail) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #updateEmail,
+          [newEmail],
+        ),
+        returnValue: _i4.Future<_i2.UpdateUserAttributeResult>.value(
+            _FakeUpdateUserAttributeResult_3(
+          this,
+          Invocation.method(
+            #updateEmail,
+            [newEmail],
+          ),
+        )),
+      ) as _i4.Future<_i2.UpdateUserAttributeResult>);
+
+  @override
+  _i4.Future<void> confirmUpdateEmail(String? confirmationCode) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #confirmUpdateEmail,
+          [confirmationCode],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
+
+  @override
+  _i4.Future<void> updatePassword({
+    required String? oldPassword,
+    required String? newPassword,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #updatePassword,
+          [],
+          {
+            #oldPassword: oldPassword,
+            #newPassword: newPassword,
+          },
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
 }
 
 /// A class which mocks [ResetPasswordResult].
@@ -285,7 +342,7 @@ class MockResetPasswordResult extends _i1.Mock
   @override
   _i2.ResetPasswordStep get nextStep => (super.noSuchMethod(
         Invocation.getter(#nextStep),
-        returnValue: _FakeResetPasswordStep_3(
+        returnValue: _FakeResetPasswordStep_4(
           this,
           Invocation.getter(#nextStep),
         ),


### PR DESCRIPTION
概要
ユーザーがサインイン後にメールアドレスとパスワードを変更できる設定機能を新たに追加しました。

これに伴い、関連するロジックのエラーハンドリングを強化し、新機能及び既存の認証フローに関するウィジェットテストの追加と修正を行いました。これにより、機能全体の安定性と信頼性が向上しています。

変更点
1. 設定機能の新規実装
UI/UXの追加

ホーム画面のAppBarに設定アイコンを追加し、設定ページへの導線を設けました。

「メールアドレス変更」と「パスワード変更」のメニューを持つ設定ページを実装しました。

メールアドレス変更機能

新しいメールアドレスを入力後、そのアドレスに送信された確認コードを用いて認証し、変更を完了する一連の画面とロジックを実装しました。

パスワード変更機能

現在のパスワードと新しいパスワードを入力することで、サインイン中のパスワードを安全に変更できる機能を実装しました。

ウィジェットテストの追加

上記の新機能（メールアドレス・パスワード変更）について、正常系・異常系を含む一連のフローを検証するウィジェットテスト (settings_flow_test.dart) を追加しました。

2. 既存機能の改善とテスト修正
AuthStateNotifier のエラーハンドリング強化

updateEmail, confirmUpdateEmail, updatePassword の各メソッドに、AuthException以外の一般的な例外も捕捉する catch ブロックを追加し、予期せぬエラーへの耐性を向上させました。

ウィジェットテストの不具合修正

パスワードポリシー違反をテストするケースで、クライアントサイドのバリデーションが原因でテストが失敗していた問題を修正しました。